### PR TITLE
Strip trailing `;` from configuration string

### DIFF
--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -175,10 +175,10 @@ class VehicleHandler:
         self.publisher.publish_str(f'{self.vehicle_prefix}/configuration/raw',
                                    self.vin_info.model_configuration_json_str)
         configuration_prefix = f'{self.vehicle_prefix}/configuration'
-        for c in self.vin_info.model_configuration_json_str.split(';'):
+        for c in self.vin_info.model_configuration_json_str.rstrip(';').split(';'):
             property_map = {}
             for e in c.split(','):
-                key_value_pair = e.split(":")
+                key_value_pair = e.split(":",1)
                 property_map[key_value_pair[0]] = key_value_pair[1]
             self.publisher.publish_str(f'{configuration_prefix}/{property_map["code"]}', property_map["value"])
         while True:


### PR DESCRIPTION
I was getting errors on startup as follows:
```
Traceback (most recent call last):
  File "/home/bisscuitt/src/SAIC-iSmart-API/saic-python-mqtt-gateway/./mqtt_gateway.py", line 729, in <module>
    mqtt_gateway.run()
  File "/home/bisscuitt/src/SAIC-iSmart-API/saic-python-mqtt-gateway/./mqtt_gateway.py", line 454, in run
    asyncio.run(main(self.vehicle_handler, message_handler, self.configuration.messages_request_interval))
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/bisscuitt/src/SAIC-iSmart-API/saic-python-mqtt-gateway/./mqtt_gateway.py", line 635, in main
    await task
  File "/home/bisscuitt/src/SAIC-iSmart-API/saic-python-mqtt-gateway/./mqtt_gateway.py", line 182, in handle_vehicle
    property_map[key_value_pair[0]] = key_value_pair[1]
IndexError: list index out of range
```

Stripping the trailing `;` from `vin_info.model_configuration_json_str` resolves the issue.