### PR TITLE
Fix crash during message parsing (and other small fixes)

### DIFF
--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -647,7 +647,9 @@ def process_arguments() -> Configuration:
                             dest='open_wp_lp_map', required=False, action=EnvDefault, envvar='OPENWB_LP_MAP')
         parser.add_argument('--saic-relogin-delay', help='How long to wait before attempting another login to the SAIC '
                                                          'API. Environment Variable: SAIC_RELOGIN_DELAY',
-                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY', type=int)
+                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY',
+                            type=int)
+
         args = parser.parse_args()
         config.mqtt_user = args.mqtt_user
         config.mqtt_password = args.mqtt_password

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -553,8 +553,7 @@ class MessageHandler:
             latest_timestamp = None
             latest_vehicle_start_message = None
             latest_vehicle_start_timestamp = None
-            for msg in message_list:
-                message = convert(msg)
+            for message in message_list:
                 logging.info(message.get_details())
 
                 if message.message_type == '323':
@@ -605,7 +604,7 @@ class EnvDefault(argparse.Action):
 async def periodic(message_handler: MessageHandler, query_messages_interval: int):
     while True:
         message_handler.polling()
-        logging.debug(f'Waiting {query_messages_interval} to check for new messages')
+        logging.debug(f'Waiting {query_messages_interval} seconds to check for new messages')
         await asyncio.sleep(float(query_messages_interval))
 
 

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -44,11 +44,11 @@ class VehicleHandler:
         self.last_car_activity = None
         self.force_update = True
         self.is_charging_on_openwb = False
-        if vin_info.vin in configuration.abrp_token_map:
-            abrp_user_token = configuration.abrp_token_map[vin_info.vin]
+        if vin_info.vin in self.configuration.abrp_token_map:
+            abrp_user_token = self.configuration.abrp_token_map[vin_info.vin]
         else:
             abrp_user_token = None
-        self.abrp_api = AbrpApi(configuration.abrp_api_key, abrp_user_token)
+        self.abrp_api = AbrpApi(self.configuration.abrp_api_key, abrp_user_token)
         self.vehicle_prefix = f'{self.configuration.saic_user}/vehicles/{self.vin_info.vin}'
         self.refresh_mode = 'periodic'
         self.inactive_refresh_interval = -1
@@ -709,7 +709,8 @@ def check_positive(value):
     return ivalue
 
 
-configuration = process_arguments()
+if __name__ == '__main__':
+    configuration = process_arguments()
 
-mqtt_gateway = MqttGateway(configuration)
-mqtt_gateway.run()
+    mqtt_gateway = MqttGateway(configuration)
+    mqtt_gateway.run()

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -646,7 +646,8 @@ def process_arguments() -> Configuration:
                             dest='open_wp_lp_map', required=False, action=EnvDefault, envvar='OPENWB_LP_MAP')
         parser.add_argument('--saic-relogin-delay', help='How long to wait before attempting another login to the SAIC '
                                                          'API. Environment Variable: SAIC_RELOGIN_DELAY',
-                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY')
+                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY',
+                            type=check_positive)
         args = parser.parse_args()
         config.mqtt_user = args.mqtt_user
         config.mqtt_password = args.mqtt_password

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -664,7 +664,7 @@ def process_arguments() -> Configuration:
                             dest='open_wp_lp_map', required=False, action=EnvDefault, envvar='OPENWB_LP_MAP')
         parser.add_argument('--saic-relogin-delay', help='How long to wait before attempting another login to the SAIC '
                                                          'API. Environment Variable: SAIC_RELOGIN_DELAY',
-                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY')
+                            dest='saic_relogin_delay', required=False, action=EnvDefault, envvar='SAIC_RELOGIN_DELAY', type=int)
         args = parser.parse_args()
         config.mqtt_user = args.mqtt_user
         config.mqtt_password = args.mqtt_password

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -9,10 +9,10 @@ from typing import cast
 
 import saic_ismart_client.saic_api
 from saic_ismart_client.abrp_api import AbrpApi, AbrpApiException
-from saic_ismart_client.ota_v1_1.data_model import Message, VinInfo, MpUserLoggingInRsp, MpAlarmSettingType
+from saic_ismart_client.ota_v1_1.data_model import VinInfo, MpUserLoggingInRsp, MpAlarmSettingType
 from saic_ismart_client.ota_v2_1.data_model import OtaRvmVehicleStatusResp25857
 from saic_ismart_client.ota_v3_0.data_model import OtaChrgMangDataResp, RvsChargingStatus
-from saic_ismart_client.saic_api import SaicApi, SaicApiException
+from saic_ismart_client.saic_api import SaicApi, SaicApiException, SaicMessage
 
 from configuration import Configuration
 from mqtt_publisher import MqttClient
@@ -32,42 +32,6 @@ def datetime_to_str(dt: datetime.datetime) -> str:
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 logging.getLogger().setLevel(level=os.getenv('LOG_LEVEL', 'INFO').upper())
-
-
-class SaicMessage:
-    def __init__(self, message_id: int, message_type: str, title: str, message_time: datetime, sender: str,
-                 content: str, read_status: int, vin: str):
-        self.message_id = message_id
-        self.message_type = message_type
-        self.title = title
-        self.message_time = message_time
-        self.sender = sender
-        self.content = content
-        self.read_status = read_status
-        self.vin = vin
-
-    def get_read_status_str(self) -> str:
-        if self.read_status is None:
-            return 'unknown'
-        elif self.read_status == 0:
-            return 'unread'
-        else:
-            return 'read'
-
-    def get_details(self) -> str:
-        return f'ID: {self.message_id}, Time: {self.message_time}, Type: {self.message_type}, Title: {self.title}, '\
-            + f'Content: {self.content}, Status: {self.get_read_status_str()}, Sender: {self.sender}, VIN: {self.vin}'
-
-
-def convert(message: Message) -> SaicMessage:
-    if message.content is not None:
-        content = message.content.decode()
-    else:
-        content = None
-    return SaicMessage(message.message_id, message.message_type, message.title.decode(),
-                       message.message_time.get_timestamp(), message.sender.decode(), content, message.read_status,
-                       message.vin)
-
 
 class VehicleHandler:
     def __init__(self, config: Configuration, saicapi: SaicApi, publisher: Publisher, vin_info: VinInfo,


### PR DESCRIPTION
Included fixes:
- Relogin delay is not parsed as a number when set from env variabile
- There's a wrong type translation of Message to SaicMessage since that has been moved into the core client library
- The application kept running even if one of the core tasks crashed, making It impossible to restart via docker, Kubernetes, etc.
- Exception logging made it difficult to see where the application was crashing

This closes #11 