### PR TITLE
Reliability fixes

### DIFF
--- a/home_assistant_discovery.py
+++ b/home_assistant_discovery.py
@@ -151,6 +151,7 @@ class HomeAssistantDiscovery:
             'current_temperature_topic': self.__get_vehicle_topic(mqtt_topics.CLIMATE_INTERIOR_TEMPERATURE),
             'current_temperature_template': '{{ value }}',
             'temperature_command_topic': self.__get_vehicle_topic(mqtt_topics.CLIMATE_REMOTE_TEMPERATURE) + '/set',
+            'temperature_command_template': '{{ value | int }}',
             'temperature_state_topic': self.__get_vehicle_topic(mqtt_topics.CLIMATE_REMOTE_TEMPERATURE),
             'temperature_state_template': '{{ value | int }}',
             'min_temp': self.__vehicle_state.get_min_ac_temperature(),


### PR DESCRIPTION
- Have HA publish temperature setpoint as int instead of float. This fixes some HA cards that publish temperature as float
- Improve the MQTT Client robustness by wrapping the on message handler with try catch. This avoids crashing the main Paho's loop