### PR TITLE
Use mqtt 3.1.1 for compatibility with nanomq

### DIFF
--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -26,7 +26,7 @@ class MqttClient(Publisher):
         self.on_ac_state_update = None
         self.on_lp_charging = None
 
-        mqtt_client = mqtt.Client(str(self.publisher_id), transport=self.transport_protocol, protocol=mqtt.MQTTv31)
+        mqtt_client = mqtt.Client(str(self.publisher_id), transport=self.transport_protocol, protocol=mqtt.MQTTv311)
         mqtt_client.on_connect = self.__on_connect
         mqtt_client.on_message = self.__on_message
         self.client = mqtt_client


### PR DESCRIPTION
Hey there. I'm using nanomq which doesn't support MQTT protocol v3.1 but only v3.1.1. The newer version seems to be pretty much backwards compatible. The code seems to work fine with 3.1.1. If there's no strong argument I suggest updating to 3.1.1.

Thanks for your awesome work with that project!