### PR TITLE
Hotfix: Publish 'online' to lwt more often

### DIFF
--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -83,6 +83,7 @@ class VehicleHandler:
         self.vehicle_state.notify_car_activity_time(start_time, True)
 
         while True:
+            self.publisher.keepalive()
             if (
                     not self.vehicle_state.is_complete()
                     and datetime.datetime.now() > start_time + datetime.timedelta(seconds=10)

--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -41,7 +41,11 @@ class MqttClient(Publisher):
                                             password=self.configuration.mqtt_password)
             else:
                 self.client.username_pw_set(username=self.configuration.mqtt_user)
-        self.client.will_set(self.get_topic(mqtt_topics.INTERNAL_LWT, False).decode('utf8'), payload='offline', retain=True)
+        self.client.will_set(
+            self.get_topic(mqtt_topics.INTERNAL_LWT, False).decode('utf8'),
+            payload='offline',
+            retain=True
+        )
         self.client.connect(host=self.host, port=self.port)
         self.client.loop_start()
         # wait until we've connected
@@ -57,7 +61,7 @@ class MqttClient(Publisher):
             self.client.subscribe(f'{mqtt_account_prefix}/{mqtt_topics.VEHICLES}/+/{mqtt_topics.REFRESH_MODE}/set')
             self.client.subscribe(f'{mqtt_account_prefix}/{mqtt_topics.VEHICLES}/+/{mqtt_topics.REFRESH_PERIOD}/+/set')
             self.client.subscribe(f'{self.configuration.open_wb_topic}/lp/+/boolChargeStat')
-            self.refresh_lwt()
+            self.keepalive()
         else:
             SystemExit(f'Unable to connect to MQTT broker. Return code: {rc}')
 
@@ -131,7 +135,3 @@ class MqttClient(Publisher):
         open_wb_topic_removed = topic[len(f'{self.configuration.open_wb_topic}') + 1:]
         elements = open_wb_topic_removed.split('/')
         return elements[1]
-
-    def refresh_lwt(self):
-        self.publish_str(mqtt_topics.INTERNAL_LWT, 'online', False)
-

--- a/publisher.py
+++ b/publisher.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+import mqtt_topics
 from configuration import Configuration
 
 
@@ -82,6 +83,9 @@ class Publisher:
                     if isinstance(item, dict):
                         data[key] = self.anonymize(item)
         return data
+
+    def keepalive(self):
+        self.publish_str(mqtt_topics.INTERNAL_LWT, 'online', False)
 
     @staticmethod
     def anonymize_str(value: str) -> str:


### PR DESCRIPTION
This prevents Home Assistant for mistakenly marking the car as 'unavailable'