### PR TITLE
Feature: Dynamic refresh period during charging

### DIFF
--- a/vehicle.py
+++ b/vehicle.py
@@ -57,6 +57,8 @@ class VehicleState:
         self.refresh_period_inactive = -1
         self.refresh_period_after_shutdown = -1
         self.refresh_period_inactive_grace = -1
+        self.refresh_period_charging = 0
+        self.charge_polling_min_percent = charge_polling_min_percent
         self.target_soc = None
         self.charge_current_limit = None
         self.refresh_period_charging = 0


### PR DESCRIPTION
This fixes #52 

Assumptions:
- We always aim for Target SoC%. 
- If for some reason we are overshooting it or we reached it but the car is still charging we assume a 1% delta is still left (e.g. during 100% cell balancing)
- We clamp the refresh period between the active and inactive one
- By default we try to reach 1% precision, but users can statically configure it. Dynamic polling can be configured by setting a really low value (e.g. 0.01%)