### PR TITLE
Add charging finished sensor

### DIFF
--- a/home_assistant_discovery.py
+++ b/home_assistant_discovery.py
@@ -67,6 +67,8 @@ class HomeAssistantDiscovery:
                               unit_of_measurement='%')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_REMAINING_CHARGING_TIME, 'Remaining charging time',
                               device_class='duration', state_class='measurement', unit_of_measurement='s')
+        self.__publish_sensor(mqtt_topics.DRIVETRAIN_REMAINING_CHARGING_TIME, 'Charging finished',
+                              device_class='timestamp', value_template='{{ (as_timestamp(now()) + value | int) }}')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_CHARGING_SCHEDULE, 'Scheduled Charging Start',
                               value_template='{{ value_json["startTime"] }}', icon='mdi:clock-start')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_CHARGING_SCHEDULE, 'Scheduled Charging End',

--- a/home_assistant_discovery.py
+++ b/home_assistant_discovery.py
@@ -68,7 +68,7 @@ class HomeAssistantDiscovery:
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_REMAINING_CHARGING_TIME, 'Remaining charging time',
                               device_class='duration', state_class='measurement', unit_of_measurement='s')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_REMAINING_CHARGING_TIME, 'Charging finished',
-                              device_class='timestamp', value_template='{{ (as_timestamp(now()) + value | int) }}')
+                              device_class='timestamp', value_template='{{ (now() + timedelta(seconds = value | int)).isoformat() }}')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_CHARGING_SCHEDULE, 'Scheduled Charging Start',
                               value_template='{{ value_json["startTime"] }}', icon='mdi:clock-start')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_CHARGING_SCHEDULE, 'Scheduled Charging End',


### PR DESCRIPTION
❗ Not tested! I suspect this does not work directly, and I have not easy method of testing this.

This adds a sensor based on the current time and remaining duration. It (should) create a human-readable sensor e.g. 'in 6 hours' but you can also easily make some automations based on 'is it in the future' etc. I personally prefer this over the remaining duration.

This is the (working) template sensor in YAML. 

```yaml
template:          
  - sensor:
      - name: "Charging finished"
        device_class: timestamp
        state: "{{ (now() + timedelta(seconds = states('sensor.<id>_remaining_charging_time') | int)).isoformat() }}"
```
<img width="513" alt="Screenshot 2023-08-07 at 09 25 24" src="https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway/assets/74970928/babcc468-acdc-42f9-bf62-0866baa1c038">
