### PR TITLE
Avoid publishing LWT message too often.

### DIFF
--- a/.github/workflows/build_python_mqtt_images.yml
+++ b/.github/workflows/build_python_mqtt_images.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_PASSWORD }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -46,8 +47,20 @@ jobs:
         with:
           string: ${{ github.repository }}
 
-      - name: Build and push
+      - name: Build and push (GHCR only)
         uses: docker/build-push-action@v4
+        if: env.DOCKERHUB_ORGANIZATION == null
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:latest
+            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:${{ env.RELEASE_VERSION }}
+
+      - name: Build and push (GHCR + DockerHub)
+        uses: docker/build-push-action@v4
+        if: env.DOCKERHUB_ORGANIZATION != null
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration parameters can be provided as command line parameters or environme
 | -m or --mqtt-uri           | MQTT_URI                 | URI to the MQTT Server. TCP: tcp://mqtt.eclipseprojects.io:1883 or WebSocket: ws://mqtt.eclipseprojects.io:9001 - **required**                                                      |
 | --mqtt-user                | MQTT_USER                | MQTT user name                                                                                                                                                                      |
 | --mqtt-password            | MQTT_PASSWORD            | MQTT password                                                                                                                                                                       |
+| --mqtt-client-id           | MQTT_CLIENT_ID           | MQTT Client Identifier. Defaults to saic-python-mqtt-gateway.                                                                                                                       |
 | --mqtt-topic-prefix        | MQTT_TOPIC               | Provide a custom MQTT prefix to replace the default: saic                                                                                                                           |
 | --saic-uri                 | SAIC_URI                 | SAIC URI. Default is the European Production endpoint: https://tap-eu.soimt.com                                                                                                     |
 | --abrp-api-key             | ABRP_API_KEY             | API key for the A Better Route Planner telemetry API. Default is the open source telemetry API key 8cfc314b-03cd-4efe-ab7d-4431cd8f2e2d.                                            |
@@ -33,6 +34,7 @@ Configuration parameters can be provided as command line parameters or environme
 | --ha-discovery             | HA_DISCOVERY_ENABLED     | Home Assistant auto-discovery is enabled (True) by default. It can be disabled (False) with this parameter.                                                                         |
 | --ha-discovery-prefix      | HA_DISCOVERY_PREFIX      | The default MQTT prefix for Home Assistant auto-discovery is 'homeassistant'. Another prefix can be configured with this parameter                                                  |
 |                            | LOG_LEVEL                | Log level: INFO (default), use DEBUG for detailed output, use CRITICAL for no output, [more info](https://docs.python.org/3/library/logging.html#levels)                            |
+|                            | MQTT_LOG_LEVEL           | Log level of the MQTT Client: INFO (default), use DEBUG for detailed output, use CRITICAL for no output, [more info](https://docs.python.org/3/library/logging.html#levels)         |
 
 ### Charging Station Configuration
 

--- a/configuration.py
+++ b/configuration.py
@@ -16,6 +16,7 @@ class Configuration:
         self.mqtt_transport_protocol = ''
         self.mqtt_user = ''
         self.mqtt_password = ''
+        self.mqtt_client_id = 'saic-python-mqtt-gateway'
         self.mqtt_topic = ''
         self.charging_stations_by_vin: dict[str, ChargingStation] = {}
         self.anonymized_publishing = False

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -518,6 +518,11 @@ def process_arguments() -> Configuration:
                             dest='mqtt_user', required=False, action=EnvDefault, envvar='MQTT_USER')
         parser.add_argument('--mqtt-password', help='The MQTT password. Environment Variable: MQTT_PASSWORD',
                             dest='mqtt_password', required=False, action=EnvDefault, envvar='MQTT_PASSWORD')
+        parser.add_argument('--mqtt-client-id', help='The MQTT Client Identifier. Environment Variable: '
+                                                     + 'MQTT_CLIENT_ID '
+                                                     + 'Default is saic-python-mqtt-gateway',
+                            default='saic-python-mqtt-gateway', dest='mqtt_client_id', required=False,
+                            action=EnvDefault, envvar='MQTT_CLIENT_ID')
         parser.add_argument('--mqtt-topic-prefix', help='MQTT topic prefix. Environment Variable: MQTT_TOPIC'
                                                         + 'Default is saic', default='saic', dest='mqtt_topic',
                             required=False, action=EnvDefault, envvar='MQTT_TOPIC')
@@ -574,6 +579,7 @@ def process_arguments() -> Configuration:
         args = parser.parse_args()
         config.mqtt_user = args.mqtt_user
         config.mqtt_password = args.mqtt_password
+        config.mqtt_client_id = args.mqtt_client_id
         config.charge_dynamic_polling_min_percentage = args.charge_dynamic_polling_min_percentage
         if args.saic_relogin_delay:
             config.saic_relogin_delay = args.saic_relogin_delay

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -77,7 +77,6 @@ class VehicleHandler:
         self.vehicle_state.notify_car_activity_time(start_time, True)
 
         while True:
-            self.publisher.keepalive()
             if (
                     not self.vehicle_state.is_complete()
                     and datetime.datetime.now() > start_time + datetime.timedelta(seconds=10)

--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import threading
-import uuid
 import paho.mqtt.client as mqtt
 
 import mqtt_topics
@@ -11,12 +10,15 @@ from publisher import Publisher
 LOG = logging.getLogger(__name__)
 LOG.setLevel(level=os.getenv('LOG_LEVEL', 'INFO').upper())
 
+MQTT_LOG = logging.getLogger(mqtt.__name__)
+MQTT_LOG.setLevel(level=os.getenv('MQTT_LOG_LEVEL', 'INFO').upper())
+
 
 class MqttClient(Publisher):
     def __init__(self, configuration: Configuration):
         super().__init__(configuration)
-        self.publisher_id = uuid.uuid4()
         self.configuration = configuration
+        self.publisher_id = self.configuration.mqtt_client_id
         self.topic_root = configuration.mqtt_topic
         self.is_connected = threading.Event()
         self.client = None
@@ -28,6 +30,7 @@ class MqttClient(Publisher):
         self.vin_by_charger_connected_topic = {}
 
         mqtt_client = mqtt.Client(str(self.publisher_id), transport=self.transport_protocol, protocol=mqtt.MQTTv311)
+        mqtt_client.enable_logger(MQTT_LOG)
         mqtt_client.on_connect = self.__on_connect
         mqtt_client.on_message = self.__on_message
         self.client = mqtt_client


### PR DESCRIPTION
This Fixes #82 and introduces some changes around the MQTT Client:

- It now uses a fixed client id to better support LWT publshing and tracking (as it is often done per client id)
- MQTT Client ID is configurabile via CLI and ENV variabiles since some MQTT brokers use it for authentication/authorization purposes
- There's a new env variable MQTT_LOG_LEVEL to control the logging level of the MQTT Client library. It defaults to INFO as usual

I've also made dockerhub publishing optional (as I don't use it in my testing fork)