### PR TITLE
Fixed an issue where setting ha_discovery_enabled to False had no effect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11-slim
 
 WORKDIR /usr/src/app
 

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -611,7 +611,7 @@ def process_arguments() -> Configuration:
 
         config.saic_password = args.saic_password
 
-        if args.ha_discovery_enabled:
+        if args.ha_discovery_enabled is not None:
             config.ha_discovery_enabled = args.ha_discovery_enabled
 
         if args.ha_discovery_prefix:


### PR DESCRIPTION
In `mqtt_gateway.py` the if statement was never entered when ha_discovery_enabled was set to False:
```python
if args.ha_discovery_enabled:
    config.ha_discovery_enabled = args.ha_discovery_enabled
```