### PR TITLE
Migrate docker base image to python:3.11-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Using the Python slim Docker images makes the size of the image more than 5 times smaller.
Also bumped the Python version to 3.11.