### PR TITLE
Correct error message in mqtt_gateway.py

### DIFF
--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -166,7 +166,7 @@ class VehicleHandler:
                             )
 
                     except ValueError as e:
-                        raise MqttGatewayException(f'Error setting SoC target: {e}')
+                        raise MqttGatewayException(f'Error setting temperature target: {e}')
                 case mqtt_topics.CLIMATE_REMOTE_CLIMATE_STATE:
                     match payload.strip().lower():
                         case 'off':


### PR DESCRIPTION
When raising an MqttGatewayException message on climate change failure, the log message states 'Error setting SoC target'. 
This appears to be a result of the exception handler message being copied from elsewhere in the code (DRIVETRAIN_SOC_TARGET operation, line 256 exception).
This PR corrects the log message when CLIMATE_REMOTE_TEMPERATURE fails.