### PR TITLE
Battery capacity for MG ZS EV Standard 2021

### DIFF
--- a/home_assistant_discovery.py
+++ b/home_assistant_discovery.py
@@ -99,8 +99,12 @@ class HomeAssistantDiscovery:
         # Standard sensors
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_SOC, 'SoC', device_class='battery', state_class='measurement',
                               unit_of_measurement='%')
-        self.__publish_sensor(mqtt_topics.DRIVETRAIN_SOC_KWH, 'SoC_kWh', device_class='ENERGY_STORAGE',
-                              state_class='measurement', unit_of_measurement='kWh')
+        self.__publish_sensor(mqtt_topics.DRIVETRAIN_SOC_KWH,
+                              'SoC_kWh',
+                              device_class='ENERGY_STORAGE',
+                              state_class='measurement',
+                              icon='mdi:battery-charging-70',
+                              unit_of_measurement='kWh')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_REMAINING_CHARGING_TIME, 'Remaining charging time',
                               device_class='duration', state_class='measurement', unit_of_measurement='s')
         custom_availability = {

--- a/vehicle.py
+++ b/vehicle.py
@@ -755,6 +755,9 @@ class VehicleState:
         # Model: MG5 Electric, variant MG5 SR Comfort
         elif self.series.startswith('EP2CP3'):
             return 50.3
+        # ZS EV Standard 2021
+        elif self.series.startswith('ZS EV S'):
+            return 49.0
         else:
             return None
 

--- a/vehicle.py
+++ b/vehicle.py
@@ -592,7 +592,7 @@ class VehicleState:
                 real_total_battery_capacity
             )
         soc_kwh = (battery_capacity_correction_factor * charge_status.realtimePower) / 10.0
-        self.publisher.publish_float(self.get_topic(mqtt_topics.DRIVETRAIN_SOC_KWH), soc_kwh)
+        self.publisher.publish_float(self.get_topic(mqtt_topics.DRIVETRAIN_SOC_KWH), round(soc_kwh, 2))
 
         if soc is not None and self.target_soc is not None and remaining_charging_time is not None:
             target_soc_percentage = self.target_soc.percentage


### PR DESCRIPTION
The API provides the famous value 725 as battery capacity for the MG ZS EV Standard 2021. In fact, it should be 490.