### PR TITLE
Avoid processing vehicle status updates if the server clock has drifted too much

### DIFF
--- a/integrations/abrp/api.py
+++ b/integrations/abrp/api.py
@@ -58,8 +58,8 @@ class AbrpApi:
             # Request
             tlm_send_url = f'{self.__base_uri}tlm/send'
             data = {
-                # We assume the timestamp is now, we will update it later from GPS if available
-                'utc': int(time.time()),
+                # We assume the timestamp is the refresh time or now, we will update it later from GPS if available
+                'utc': int(vehicle_status.statusTime) or int(time.time()),
                 'soc': (charge_status.bmsPackSOCDsp / 10.0),
                 'is_charging': vehicle_status.is_charging,
                 'is_parked': vehicle_status.is_parked,

--- a/integrations/home_assistant/discovery.py
+++ b/integrations/home_assistant/discovery.py
@@ -247,7 +247,11 @@ class HomeAssistantDiscovery:
                                   )
                               ]))
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_CHARGING_TYPE, 'Charging Mode',
-                              entity_category='diagnostic')
+                              entity_category='diagnostic',
+                              enabled=False)
+        self.__publish_sensor(mqtt_topics.BMS_CHARGE_STATUS, 'BMS Charge Status',
+                              entity_category='diagnostic',
+                              enabled=False)
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_MILEAGE, 'Mileage', device_class='distance',
                               state_class='total_increasing', unit_of_measurement='km')
         self.__publish_sensor(mqtt_topics.DRIVETRAIN_MILEAGE_OF_DAY, 'Mileage of the day', device_class='distance',

--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -380,7 +380,7 @@ class VehicleHandler:
                     # set mode, period (in)-active,...
                     await self.vehicle_state.configure_by_message(topic=topic, payload=payload)
             self.publisher.publish_str(f'{self.vehicle_prefix}/{topic}/result', 'Success')
-            self.vehicle_state.set_refresh_mode(RefreshMode.FORCE)
+            self.vehicle_state.set_refresh_mode(RefreshMode.FORCE, f'after command execution on topic {topic}')
         except MqttGatewayException as e:
             self.publisher.publish_str(f'{self.vehicle_prefix}/{topic}/result', f'Failed: {e.message}')
             LOG.exception(e.message, exc_info=e)

--- a/mqtt_topics.py
+++ b/mqtt_topics.py
@@ -67,6 +67,9 @@ OBC = 'obc'
 OBC_CURRENT = OBC + '/current'
 OBC_VOLTAGE = OBC + '/voltage'
 
+BMS = 'bms'
+BMS_CHARGE_STATUS = BMS + '/chargeStatus'
+
 INFO = 'info'
 INFO_BRAND = INFO + '/brand'
 INFO_MODEL = INFO + '/model'

--- a/tests/test_vehicle_handler.py
+++ b/tests/test_vehicle_handler.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from unittest.mock import patch
 
@@ -77,6 +78,7 @@ LIGHTS_SIDE = False
 
 def mock_vehicle_status(mocked_vehicle_status):
     vehicle_status_resp = VehicleStatusResp(
+        statusTime=int(time.time()),
         basicVehicleStatus=BasicVehicleStatus(
             engineStatus=0,
             extendedData2=2,

--- a/vehicle.py
+++ b/vehicle.py
@@ -196,10 +196,9 @@ class VehicleState:
         now_time = datetime.datetime.now(tz=datetime.timezone.utc)
         vehicle_status_drift = abs(now_time - vehicle_status_time)
         if vehicle_status_drift > datetime.timedelta(minutes=15):
-            # raise MqttGatewayException(
-            #    f"Vehicle status time drifted too much from current time: {vehicle_status_drift}"
-            # )
-            return
+            raise MqttGatewayException(
+                f"Vehicle status time drifted too much from current time: {vehicle_status_drift}"
+            )
 
         is_engine_running = vehicle_status.is_engine_running
         self.is_charging = vehicle_status.is_charging

--- a/vehicle.py
+++ b/vehicle.py
@@ -106,6 +106,7 @@ class VehicleState:
 
     def set_refresh_period_charging(self, seconds: int):
         # Do not refresh more than the active period and less than the inactive one
+        seconds = round(seconds)
         seconds = min(max(seconds, self.refresh_period_active), self.refresh_period_inactive) if seconds > 0 else 0
         self.publisher.publish_int(self.get_topic(mqtt_topics.REFRESH_PERIOD_CHARGING), seconds)
         human_readable_period = str(datetime.timedelta(seconds=seconds))
@@ -279,7 +280,8 @@ class VehicleState:
         self.__publish_tyre(basic_vehicle_status.rearRightTyrePressure, mqtt_topics.TYRES_REAR_RIGHT_PRESSURE)
 
         self.publisher.publish_bool(self.get_topic(mqtt_topics.LIGHTS_MAIN_BEAM), basic_vehicle_status.mainBeamStatus)
-        self.publisher.publish_bool(self.get_topic(mqtt_topics.LIGHTS_DIPPED_BEAM), basic_vehicle_status.dippedBeamStatus)
+        self.publisher.publish_bool(self.get_topic(mqtt_topics.LIGHTS_DIPPED_BEAM),
+                                    basic_vehicle_status.dippedBeamStatus)
         self.publisher.publish_bool(self.get_topic(mqtt_topics.LIGHTS_SIDE), basic_vehicle_status.sideLightStatus)
 
         self.publisher.publish_str(self.get_topic(mqtt_topics.CLIMATE_REMOTE_CLIMATE_STATE),
@@ -746,7 +748,7 @@ class VehicleState:
                 computed_refresh_period = time_for_1pct
             self.set_refresh_period_charging(computed_refresh_period)
         elif not self.is_charging:
-            # Reset the charging refresh period if we detected we are not longer charging
+            # Reset the charging refresh period if we detected we are no longer charging
             self.set_refresh_period_charging(0)
         else:
             # Otherwise let's keep the last computed refresh period

--- a/vehicle.py
+++ b/vehicle.py
@@ -604,6 +604,10 @@ class VehicleState:
                 estimated_electrical_range
             )
 
+        bms_chrg_sts = charge_mgmt_data.bmsChrgSts
+        if bms_chrg_sts is not None:
+            self.publisher.publish_int(self.get_topic(mqtt_topics.BMS_CHARGE_STATUS), bms_chrg_sts)
+
         charge_status = charge_info_resp.rvsChargeStatus
         fuel_range_elec = charge_status.fuelRangeElec
         if value_in_range(fuel_range_elec, 0, 65535):

--- a/vehicle.py
+++ b/vehicle.py
@@ -453,9 +453,9 @@ class VehicleState:
         if value is None:
             self.__failed_refresh_counter = 0
             self.__refresh_period_error = self.refresh_period_active
-        else:
+        elif self.__refresh_period_error < self.refresh_period_inactive:
             self.__refresh_period_error = round(min(
-                self.refresh_period_active + 0.5 * ((2 ** self.__failed_refresh_counter) - 1),
+                self.refresh_period_active * (2 ** self.__failed_refresh_counter),
                 self.refresh_period_inactive
             ))
             self.__failed_refresh_counter = self.__failed_refresh_counter + 1

--- a/vehicle.py
+++ b/vehicle.py
@@ -384,10 +384,6 @@ class VehicleState:
                 return True
             # RefreshMode.PERIODIC is treated like default
             case _:
-                if self.last_successful_refresh is None:
-                    self.mark_successful_refresh()
-                    return True
-
                 last_actual_poll = self.last_successful_refresh
                 if self.last_failed_refresh is not None:
                     last_actual_poll = max(last_actual_poll, self.last_failed_refresh)


### PR DESCRIPTION
Today we noticed a new failure scenario:
- API is responding properly
- Vehicle status message contains a timestamp too far in the future in the statusTime field
- Vehicle status message then contains bogus data that gets misinterprted as "car is active"

Let's consider those messages as a failed gateway refresh