### PR TITLE
Remove special characters from MQTT topics.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   saic-mqtt-gateway:
     image: "saicismartapi/saic-python-mqtt-gateway:latest"

--- a/publisher/mqtt_publisher.py
+++ b/publisher/mqtt_publisher.py
@@ -145,7 +145,7 @@ class MqttClient(Publisher):
         return
 
     def publish(self, topic: str, payload) -> None:
-        self.client.publish(topic, payload, retain=True)
+        self.client.publish(self.remove_special_mqtt_characters(topic), payload, retain=True)
 
     def get_topic(self, key: str, no_prefix: bool) -> str:
         if no_prefix:

--- a/publisher/mqtt_publisher.py
+++ b/publisher/mqtt_publisher.py
@@ -152,7 +152,7 @@ class MqttClient(Publisher):
             topic = key
         else:
             topic = f'{self.topic_root}/{key}'
-        return topic
+        return self.remove_special_mqtt_characters(topic)
 
     def publish_json(self, key: str, data: dict, no_prefix: bool = False) -> None:
         payload = self.dict_to_anonymized_json(data)


### PR DESCRIPTION
Email addresses can contain special characters like the plus sign (+) that cannot appear in MQTT topics. Since the SAIC user name can be an email address and we use this information as part of the MQTT topics, we need to remove special characters.

This has already been done for subscribing to the setter-topics.

However, it's still missing for publishing MQTT messages and in the Home Assistant auto-discovery messages.