### PR TITLE
add random delay before pushing discovery

### DIFF
--- a/mqtt_gateway.py
+++ b/mqtt_gateway.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import sys
+from random import uniform
 from typing import override, Optional
 
 import apscheduler.schedulers.asyncio
@@ -184,6 +185,8 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
             case self.configuration.ha_lwt_topic:
                 if payload == 'online':
                     for (vin, vh) in self.vehicle_handlers.items():
+                        # wait randomly between 0.1 and 10 seconds before sending discovery
+                        await asyncio.sleep(uniform(0.1, 10.0))
                         LOG.debug(f'Send HomeAssistant discovery for car {vin}')
                         vh.publish_ha_discovery_messages(force=True)
             case _:


### PR DESCRIPTION
based on https://github.com/SAIC-iSmart-API/saic-python-mqtt-gateway/issues/292#issuecomment-2582676985:

I would not add a random delay between every message but between every car seems to be legit.

I for now implemented a random wait between 0.1 and 10 seconds. Does that seem legit?

In my case it was OK to have the discovery messages there instantly (without any wait) but I think there is reason why to wait at least a bit :)