### PR TITLE
Update README.md to fix Python run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To run the service from the command line you need to have Python version 3.12 or
 Launch the MQTT gateway with the mandatory parametersn and, optionally, the url to the MQTT broker.
 
 ```
-$ python ./mqtt_gateway.py -m tcp://my-broker-host:1883 -u <saic-user> -p <saic-pwd>
+$ python ./main.py -m tcp://my-broker-host:1883 -u <saic-user> -p <saic-pwd>
 ```
 
 ### In a docker container


### PR DESCRIPTION
Documentation still references the use of mqtt_gateway.py, however this is no longer runnable, and main.py should be used instead.