### PR TITLE
Add versioning labels and start-up message to Docker image for MQTT Gateway

### DIFF
--- a/.github/workflows/build_python_mqtt_dev_images.yml
+++ b/.github/workflows/build_python_mqtt_dev_images.yml
@@ -52,6 +52,8 @@ jobs:
         if: env.DOCKERHUB_ORGANIZATION == null
         with:
           context: .
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           cache-from: type=gha
@@ -65,6 +67,8 @@ jobs:
         if: env.DOCKERHUB_ORGANIZATION != null
         with:
           context: .
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           cache-from: type=gha

--- a/.github/workflows/build_python_mqtt_images.yml
+++ b/.github/workflows/build_python_mqtt_images.yml
@@ -52,6 +52,8 @@ jobs:
         if: env.DOCKERHUB_ORGANIZATION == null
         with:
           context: .
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
@@ -63,6 +65,8 @@ jobs:
         if: env.DOCKERHUB_ORGANIZATION != null
         with:
           context: .
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ FROM python:${PYTHON_VERSION}-slim AS runtime
 
 ARG RELEASE_VERSION=latest
 
-LABEL mqtt.gateway.version="${RELEASE_VERSION}"
-LABEL mqtt.gateway.description="Python MQTT Gateway"
+LABEL saic.mqtt.gateway.version="${RELEASE_VERSION}"
+LABEL saic.mqtt.gateway.description="SAIC MQTT Gateway: A Python-based service that queries the SAIC API, processes the data, and publishes it to an MQTT broker."
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ LABEL mqtt.gateway.description="Python MQTT Gateway"
 
 WORKDIR /usr/src/app
 
+ENV RELEASE_VERSION=${RELEASE_VERSION}
 ENV VIRTUAL_ENV=/usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ ARG PYTHON_VERSION=3.12
 
 FROM weastur/poetry:${POETRY_VERSION}-python-${PYTHON_VERSION} AS builder
 
+ARG RELEASE_VERSION=latest
+
+LABEL mqtt.gateway.version="${RELEASE_VERSION}"
+LABEL mqtt.gateway.description="Python MQTT Gateway"
+
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_NO_INTERACTION=1
 ENV POETRY_VIRTUALENVS_IN_PROJECT=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ ARG PYTHON_VERSION=3.12
 
 FROM weastur/poetry:${POETRY_VERSION}-python-${PYTHON_VERSION} AS builder
 
-ARG RELEASE_VERSION=latest
-
-LABEL mqtt.gateway.version="${RELEASE_VERSION}"
-LABEL mqtt.gateway.description="Python MQTT Gateway"
-
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_NO_INTERACTION=1
 ENV POETRY_VIRTUALENVS_IN_PROJECT=1
@@ -42,6 +37,11 @@ RUN --mount=type=tmpfs,target=/root/.cargo poetry install --no-root && rm -rf $P
 # Now let's build the runtime image from the builder.
 #   We'll just copy the env and the PATH reference.
 FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ARG RELEASE_VERSION=latest
+
+LABEL mqtt.gateway.version="${RELEASE_VERSION}"
+LABEL mqtt.gateway.description="Python MQTT Gateway"
 
 WORKDIR /usr/src/app
 

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -1,6 +1,7 @@
 import asyncio
 import faulthandler
 import logging
+import os
 import signal
 import sys
 from random import uniform
@@ -230,6 +231,10 @@ if __name__ == '__main__':
     from log_config import setup_logging, debug_log_enabled
 
     setup_logging()
+
+    LOG.info(
+        f"Starting SAIC MQTT Gateway version {os.environ.get('RELEASE_VERSION', 'unknown')}"
+    )
 
     # Enable fault handler to get a thread dump on SIGQUIT
     faulthandler.enable(file=sys.stderr, all_threads=True)


### PR DESCRIPTION
I often found myself wondering which version of the MQTT Gateway I was using. To improve clarity and traceability, I have made the following updates to the Docker image:

* **Added labels** to the Docker image for **versioning** (`saic.mqtt.gateway.version`) and **description** (`saic.mqtt.gateway.description`).
* **Introduced a start-up message** that displays the `RELEASE_VERSION` environment variable when the container starts, helping users easily identify the version running.