### PR TITLE
fix: Fix OpenWB logging error due to type mismatch

### DIFF
--- a/src/integrations/openwb/__init__.py
+++ b/src/integrations/openwb/__init__.py
@@ -50,7 +50,7 @@ class OpenWBIntegration:
         soc_topic = self.__charging_station.soc_topic
         soc = extractors.extract_soc(vehicle_status, charge_status)
         if soc is not None and soc_topic is not None:
-            LOG.info("OpenWB Integration published SoC to %f", soc_topic)
+            LOG.info("OpenWB Integration published SoC to %s", soc_topic)
             self.__publisher.publish_float(
                 key=soc_topic,
                 value=soc,


### PR DESCRIPTION
I ran into #354 and tried out the PreRelease as a fix. It works, but there's an error every time the charging state is set because the log formatting is wrong.