### PR TITLE
Fix VehicleStatus timestamp drift for invalid placeholder values

### DIFF
--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -61,7 +61,7 @@ class VehicleStatusRespPublisher(
             _logger.debug("Skipping vehicle status drift check because of invalid timestamp value: %s", vehicle_status.statusTime)
         else:
             vehicle_status_time = datetime.datetime.fromtimestamp(
-                vehicle_status.statusTime, tz=datetime.UTC
+                float(vehicle_status.statusTime), tz=datetime.UTC
             )
             now_time = datetime.datetime.now(tz=datetime.UTC)
             vehicle_status_drift = abs(now_time - vehicle_status_time)

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import datetime
+import logging
 from typing import TYPE_CHECKING, Final, override
 
 from saic_ismart_client_ng.api.vehicle import VehicleStatusResp
@@ -24,6 +25,8 @@ if TYPE_CHECKING:
 
     from publisher.core import Publisher
     from vehicle_info import VehicleInfo
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -54,15 +57,23 @@ class VehicleStatusRespPublisher(
     def publish(
         self, vehicle_status: VehicleStatusResp
     ) -> VehicleStatusRespProcessingResult:
-        vehicle_status_time = datetime.datetime.fromtimestamp(
-            vehicle_status.statusTime or 0, tz=datetime.UTC
-        )
-        now_time = datetime.datetime.now(tz=datetime.UTC)
-        vehicle_status_drift = abs(now_time - vehicle_status_time)
+        if vehicle_status.statusTime in (0, 2147483647):
+            _logger.debug("Skipping vehicle status drift check because of invalid timestamp value: %s", vehicle_status.statusTime)
+        else:
+            vehicle_status_time = datetime.datetime.fromtimestamp(
+                vehicle_status.statusTime, tz=datetime.UTC
+            )
+            now_time = datetime.datetime.now(tz=datetime.UTC)
+            vehicle_status_drift = abs(now_time - vehicle_status_time)
+            _logger.debug("Vehicle status timestamp: %s, current UTC time: %s, drift: %s",
+                vehicle_status_time,
+                now_time,
+                vehicle_status_drift
+            )
 
-        if vehicle_status_drift > datetime.timedelta(minutes=15):
-            msg = f"Vehicle status time drifted more than 15 minutes from current time: {vehicle_status_drift}. Server reported {vehicle_status_time}"
-            raise MqttGatewayException(msg)
+            if vehicle_status_drift > datetime.timedelta(minutes=15):
+                msg = f"Vehicle status time drifted more than 15 minutes from current time: {vehicle_status_drift}. Server reported {vehicle_status_time}"
+                raise MqttGatewayException(msg)
 
         basic_vehicle_status = vehicle_status.basicVehicleStatus
         if basic_vehicle_status:

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -57,18 +57,25 @@ class VehicleStatusRespPublisher(
     def publish(
         self, vehicle_status: VehicleStatusResp
     ) -> VehicleStatusRespProcessingResult:
-        if vehicle_status.statusTime in (None, 0, 2147483647):
-            _logger.debug("Skipping vehicle status drift check because of invalid timestamp value: %s", vehicle_status.statusTime)
+        if vehicle_status.statusTime is None or vehicle_status.statusTime in (
+            0,
+            2147483647,
+        ):
+            _logger.debug(
+                "Skipping vehicle status drift check because of invalid timestamp value: %s",
+                vehicle_status.statusTime,
+            )
         else:
             vehicle_status_time = datetime.datetime.fromtimestamp(
-                float(vehicle_status.statusTime), tz=datetime.UTC
+                vehicle_status.statusTime, tz=datetime.UTC
             )
             now_time = datetime.datetime.now(tz=datetime.UTC)
             vehicle_status_drift = abs(now_time - vehicle_status_time)
-            _logger.debug("Vehicle status timestamp: %s, current UTC time: %s, drift: %s",
+            _logger.debug(
+                "Vehicle status timestamp: %s, current UTC time: %s, drift: %s",
                 vehicle_status_time,
                 now_time,
-                vehicle_status_drift
+                vehicle_status_drift,
             )
 
             if vehicle_status_drift > datetime.timedelta(minutes=15):

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -57,7 +57,7 @@ class VehicleStatusRespPublisher(
     def publish(
         self, vehicle_status: VehicleStatusResp
     ) -> VehicleStatusRespProcessingResult:
-        if vehicle_status.statusTime in (0, 2147483647):
+        if vehicle_status.statusTime in (None, 0, 2147483647):
             _logger.debug("Skipping vehicle status drift check because of invalid timestamp value: %s", vehicle_status.statusTime)
         else:
             vehicle_status_time = datetime.datetime.fromtimestamp(


### PR DESCRIPTION
# **Fix VehicleStatus timestamp drift (#391)**

## **Description**

This pull request fixes the issue where `MqttGatewayException` was occasionally raised when the API returned the invalid timestamp `2147483647`.

* Invalid placeholder timestamps are now skipped.
* Valid timestamps are correctly converted to `datetime`.
* Drift checks still work for valid timestamps.

## **Fixes**

* Closes #391