### PR TITLE
Handle PHEV ignore codes for target SOC and scheduled charging

### DIFF
--- a/src/status_publisher/charge/chrg_mgmt_data.py
+++ b/src/status_publisher/charge/chrg_mgmt_data.py
@@ -87,7 +87,7 @@ class ChrgMgmtDataPublisher(
 
         raw_target_soc = charge_mgmt_data.bmsOnBdChrgTrgtSOCDspCmd
         target_soc: TargetBatteryCode | None = None
-        if raw_target_soc is not None:
+        if raw_target_soc is not None and raw_target_soc != 0:
             try:
                 target_soc = TargetBatteryCode(raw_target_soc)
             except ValueError:
@@ -179,6 +179,8 @@ class ChrgMgmtDataPublisher(
             and charge_mgmt_data.bmsReserStMintueDspCmd is not None
             and charge_mgmt_data.bmsReserSpHourDspCmd is not None
             and charge_mgmt_data.bmsReserSpMintueDspCmd is not None
+            and charge_mgmt_data.bmsReserCtrlDspCmd is not None
+            and charge_mgmt_data.bmsReserCtrlDspCmd != 0
         ):
             try:
                 start_hour = charge_mgmt_data.bmsReserStHourDspCmd

--- a/tests/common_mocks.py
+++ b/tests/common_mocks.py
@@ -130,7 +130,11 @@ def get_mock_vehicle_status_resp() -> VehicleStatusResp:
     )
 
 
-def get_mock_charge_management_data_resp() -> ChrgMgmtDataResp:
+def get_mock_charge_management_data_resp(
+    *,
+    bms_on_bd_chrg_trgt_soc_dsp_cmd: int | None = None,
+    bms_reser_ctrl_dsp_cmd: int | None = None,
+) -> ChrgMgmtDataResp:
     return ChrgMgmtDataResp(
         chrgMgmtData=ChrgMgmtData(
             bmsPackCrntV=0,
@@ -140,6 +144,8 @@ def get_mock_charge_management_data_resp() -> ChrgMgmtDataResp:
             bmsEstdElecRng=int(DRIVETRAIN_HYBRID_ELECTRICAL_RANGE * 10.0),
             ccuEleccLckCtrlDspCmd=1,
             bmsChrgSts=1 if DRIVETRAIN_CHARGING else 0,
+            bmsOnBdChrgTrgtSOCDspCmd=bms_on_bd_chrg_trgt_soc_dsp_cmd,
+            bmsReserCtrlDspCmd=bms_reser_ctrl_dsp_cmd,
         ),
         rvsChargeStatus=RvsChargeStatus(
             mileageOfDay=int(DRIVETRAIN_MILEAGE_OF_DAY * 10.0),

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -112,6 +112,18 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         else:
             self.fail(f"MQTT map does not contain topic {topic}")
 
+    def test_handle_charge_status_with_phev_ignore_values(self) -> None:
+        """PHEV vehicles send P_IGNORE (0) for target SOC and 0 for scheduled charging mode."""
+        chrg_mgmt_data_resp = get_mock_charge_management_data_resp(
+            bms_on_bd_chrg_trgt_soc_dsp_cmd=0,
+            bms_reser_ctrl_dsp_cmd=0,
+        )
+        result = self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
+
+        assert result.target_soc is None
+        assert result.scheduled_charging is None
+        assert self.get_topic(mqtt_topics.DRIVETRAIN_SOC_TARGET) not in self.publisher.map
+
     @staticmethod
     def get_topic(sub_topic: str) -> str:
         return f"/vehicles/{VIN}/{sub_topic}"


### PR DESCRIPTION
## Summary
- PHEV vehicles (e.g. MG EHS) send `0` for target SOC (`TargetBatteryCode.P_IGNORE`) and scheduled charging mode (`bmsReserCtrlDspCmd`), which are not valid operational values
- Filter out these zero values early in `ChrgMgmtDataPublisher`, consistent with how `ChargeCurrentLimitCode.C_IGNORE` is already handled for charge current limit
- This prevents `ValueError: Unknown target battery code: TargetBatteryCode.P_IGNORE` crash and `ValueError: 0 is not a valid ScheduledChargingMode` error

## Test plan
- [x] Added test for PHEV ignore values (target SOC = 0, scheduled charging mode = 0)
- [ ] Verify with an actual MG EHS PHEV that charge status updates no longer crash

Fixes #379