### PR TITLE
fix: preserve meaningful stop reasons for battery heating and charging

### DIFF
--- a/src/status_publisher/charge/chrg_mgmt_data.py
+++ b/src/status_publisher/charge/chrg_mgmt_data.py
@@ -8,7 +8,9 @@ from typing import override
 
 from saic_ismart_client_ng.api.vehicle_charging import (
     ChargeCurrentLimitCode,
+    ChargingStopReason,
     ChrgMgmtData,
+    HeatingStopReason,
     ScheduledChargingMode,
     TargetBatteryCode,
 )
@@ -110,6 +112,7 @@ class ChrgMgmtDataPublisher(
         self._transform_and_publish(
             topic=mqtt_topics.DRIVETRAIN_CHARGING_STOP_REASON,
             value=charge_mgmt_data.charging_stop_reason,
+            validator=lambda x: x != ChargingStopReason.NO_REASON,
             transform=lambda x: f"UNKNOWN {charge_mgmt_data.bmsChrgSpRsn}"
             if x is None
             else x.name,
@@ -149,6 +152,7 @@ class ChrgMgmtDataPublisher(
         self._transform_and_publish(
             topic=mqtt_topics.DRIVETRAIN_BATTERY_HEATING_STOP_REASON,
             value=charge_mgmt_data.heating_stop_reason,
+            validator=lambda x: x != HeatingStopReason.NO_REASON,
             transform=lambda x: f"UNKNOWN ({charge_mgmt_data.bmsPTCHeatResp})"
             if x is None
             else x.name,


### PR DESCRIPTION
## Summary

Fixes #396. The API resets `bmsPTCHeatResp` and `bmsChrgSpRsn` back to `0` (`NO_REASON`) quickly after heating/charging stops. Since the gateway polls periodically, the next poll overwrites the meaningful stop reason (e.g. `REACHED_STOP_TIME`, `UNNECESSARY`) with `NO_REASON`.

Adds a validator to skip publishing when the stop reason is `NO_REASON`, so the last meaningful value is preserved as a retained MQTT message. Applies to both:
- `drivetrain/batteryHeatingStopReason` (`HeatingStopReason.NO_REASON`)
- `drivetrain/chargingStopReason` (`ChargingStopReason.NO_REASON`)

The binary sensors for battery heating and charging status already indicate whether the process is currently active, so `NO_REASON` carries no useful information.

## Test plan

- [x] All 67 tests pass
- [x] ruff lint clean
- [ ] Verify that a meaningful stop reason (e.g. `REACHED_STOP_TIME`) survives across subsequent polls
- [ ] Verify that stop reasons from command responses (`ChrgPtcHeatResp`) are still published correctly (separate code path, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)