### PR TITLE
fix: remove deprecated object_id from HA MQTT discovery payloads

### DIFF
--- a/src/integrations/home_assistant/base.py
+++ b/src/integrations/home_assistant/base.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import abc
 from abc import abstractmethod
-from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
+
+from utils import get_gateway_version
 
 if TYPE_CHECKING:
     from integrations.home_assistant.availability import HaCustomAvailabilityConfig
 
-try:
-    _GATEWAY_VERSION = version("saic-python-mqtt-gateway")
-except PackageNotFoundError:
-    _GATEWAY_VERSION = "unknown"
+_GATEWAY_VERSION = get_gateway_version()
 _ORIGIN = {
     "name": "SAIC Python MQTT Gateway",
     "sw": _GATEWAY_VERSION,

--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -820,7 +820,6 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             "device": self.__get_device_node(),
             "o": _ORIGIN,
             "unique_id": unique_id,
-            "object_id": unique_id,
             "default_entity_id": f"{domain}.{unique_id}",
         }
 

--- a/src/integrations/home_assistant/gateway_discovery.py
+++ b/src/integrations/home_assistant/gateway_discovery.py
@@ -135,7 +135,6 @@ class HomeAssistantGatewayDiscovery(HomeAssistantDiscoveryBase):
             "device": self.__get_device_node(),
             "o": _ORIGIN,
             "unique_id": unique_id,
-            "object_id": unique_id,
             "default_entity_id": f"{domain}.{unique_id}",
         }
 

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 from asyncio import Task
 import datetime
-from importlib.metadata import version
 import logging
 from random import uniform
 import re
@@ -25,7 +24,7 @@ from publisher.core import MqttCommandListener, Publisher
 from publisher.log_publisher import ConsolePublisher
 from publisher.mqtt_publisher import MqttPublisher
 from saic_api_listener import MqttGatewaySaicApiListener
-from utils import datetime_to_str
+from utils import datetime_to_str, get_gateway_version
 from vehicle import VehicleState
 from vehicle_info import VehicleInfo
 
@@ -205,7 +204,7 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
         await self.__refresh_user_timezone()
         self.__publish_account_str(
             mqtt_topics.ACCOUNT_GATEWAY_VERSION,
-            version("saic-python-mqtt-gateway"),
+            get_gateway_version(),
         )
         self.__publish_account_int(
             mqtt_topics.ACCOUNT_REFRESH_INTERVAL,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from importlib.metadata import PackageNotFoundError, version
+import os
 from typing import TYPE_CHECKING, TypeVar
 
 from saic_ismart_client_ng.api.schema import GpsStatus
@@ -50,6 +52,13 @@ def get_update_timestamp(vehicle_status: VehicleStatusResp) -> datetime:
     if reference_drift < timedelta(minutes=15):
         return reference_time
     return now_time
+
+
+def get_gateway_version() -> str:
+    try:
+        return version("saic-python-mqtt-gateway")
+    except PackageNotFoundError:
+        return os.environ.get("RELEASE_VERSION", "unknown")
 
 
 def datetime_to_str(dt: datetime) -> str:


### PR DESCRIPTION
Fixes #376 