### PR TITLE
Parallelize multi-arch Docker builds with reusable workflow

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -1,0 +1,132 @@
+---
+name: Build Docker images
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: 'The primary tag for the image (e.g., latest, dev)'
+        required: true
+        type: string
+      version-tag:
+        description: 'The version tag (e.g., 1.2.3, 1.2.3-rc1)'
+        required: true
+        type: string
+      use-cache:
+        description: 'Whether to use GHA build cache'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_PASSWORD:
+        required: false
+      DOCKERHUB_ORGANIZATION:
+        required: false
+
+env:
+  IMAGE_NAME: saic-mqtt-gateway
+  DOCKERHUB_IMAGE_NAME: saic-python-mqtt-gateway
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - linux/arm/v7
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set platform slug
+        id: platform
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - id: lowercase-repository
+        name: Lowercase repository
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: |
+            RELEASE_VERSION=${{ inputs.version-tag }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          cache-from: ${{ inputs.use-cache && 'type=gha' || '' }}
+          cache-to: ${{ inputs.use-cache && 'type=gha,mode=max' || '' }}
+          tags: |
+            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}-${{ steps.platform.outputs.slug }}
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION == null && secrets.DOCKERHUB_USERNAME || secrets.DOCKERHUB_ORGANIZATION }}
+    steps:
+      - id: lowercase-repository
+        name: Lowercase repository
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: env.DOCKERHUB_USERNAME != null
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create GHCR multi-arch manifest
+        run: |
+          GHCR_BASE="ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
+          for tag in "${{ inputs.image-tag }}" "${{ inputs.version-tag }}"; do
+            docker buildx imagetools create -t "${GHCR_BASE}:${tag}" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-amd64" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-arm64" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-arm-v7"
+          done
+
+      - name: Create DockerHub multi-arch manifest
+        if: env.DOCKERHUB_ORGANIZATION != null
+        run: |
+          GHCR_BASE="ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
+          DH_BASE="${{ env.DOCKERHUB_ORGANIZATION }}/${{ env.DOCKERHUB_IMAGE_NAME }}"
+          for tag in "${{ inputs.image-tag }}" "${{ inputs.version-tag }}"; do
+            docker buildx imagetools create -t "${DH_BASE}:${tag}" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-amd64" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-arm64" \
+              "${GHCR_BASE}:${{ inputs.image-tag }}-linux-arm-v7"
+          done

--- a/.github/workflows/build_python_mqtt_dev_images.yml
+++ b/.github/workflows/build_python_mqtt_dev_images.yml
@@ -1,3 +1,4 @@
+---
 name: 'build dev images'
 
 on:
@@ -5,76 +6,13 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
-# TODO: only request needed permissions
 permissions: write-all
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # support dockerhub organizations. If none is present, use the dockerhub username
-      DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION == null && secrets.DOCKERHUB_USERNAME || secrets.DOCKERHUB_ORGANIZATION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: env.DOCKERHUB_USERNAME != null
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - id: lowercase-repository
-        name: lowercase repository
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ github.repository }}
-
-      - name: Build and push (GHCR only)
-        uses: docker/build-push-action@v5
-        if: env.DOCKERHUB_ORGANIZATION == null
-        with:
-          context: .
-          build-args: |
-            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:dev
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:${{ env.RELEASE_VERSION }}
-
-      - name: Build and push (GHCR + DockerHub)
-        uses: docker/build-push-action@v5
-        if: env.DOCKERHUB_ORGANIZATION != null
-        with:
-          context: .
-          build-args: |
-            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:dev
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:${{ env.RELEASE_VERSION }}
-            ${{ secrets.DOCKERHUB_ORGANIZATION != null && format('{0}/saic-python-mqtt-gateway:dev', secrets.DOCKERHUB_ORGANIZATION)}}
-            ${{ secrets.DOCKERHUB_ORGANIZATION != null && format('{0}/saic-python-mqtt-gateway:{1}', secrets.DOCKERHUB_ORGANIZATION, env.RELEASE_VERSION)}}
+  build-images:
+    uses: ./.github/workflows/build_docker_images.yml
+    with:
+      image-tag: dev
+      version-tag: ${{ github.ref_name }}
+      use-cache: true
+    secrets: inherit

--- a/.github/workflows/build_python_mqtt_images.yml
+++ b/.github/workflows/build_python_mqtt_images.yml
@@ -1,3 +1,4 @@
+---
 name: 'build stable images'
 
 on:
@@ -5,72 +6,13 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
-# TODO: only request needed permissions
 permissions: write-all
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # support dockerhub organizations. If none is present, use the dockerhub username
-      DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION == null && secrets.DOCKERHUB_USERNAME || secrets.DOCKERHUB_ORGANIZATION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: env.DOCKERHUB_USERNAME != null
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - id: lowercase-repository
-        name: lowercase repository
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ github.repository }}
-
-      - name: Build and push (GHCR only)
-        uses: docker/build-push-action@v5
-        if: env.DOCKERHUB_ORGANIZATION == null
-        with:
-          context: .
-          build-args: |
-            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:latest
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:${{ env.RELEASE_VERSION }}
-
-      - name: Build and push (GHCR + DockerHub)
-        uses: docker/build-push-action@v5
-        if: env.DOCKERHUB_ORGANIZATION != null
-        with:
-          context: .
-          build-args: |
-            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: |
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:latest
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/saic-mqtt-gateway:${{ env.RELEASE_VERSION }}
-            ${{ secrets.DOCKERHUB_ORGANIZATION != null && format('{0}/saic-python-mqtt-gateway:latest', secrets.DOCKERHUB_ORGANIZATION)}}
-            ${{ secrets.DOCKERHUB_ORGANIZATION != null && format('{0}/saic-python-mqtt-gateway:{1}', secrets.DOCKERHUB_ORGANIZATION, env.RELEASE_VERSION)}}
+  build-images:
+    uses: ./.github/workflows/build_docker_images.yml
+    with:
+      image-tag: latest
+      version-tag: ${{ github.ref_name }}
+      use-cache: false
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Extract shared Docker build logic into a reusable workflow (`build_docker_images.yml`)
- Split platform builds into 3 parallel jobs (amd64, arm64, armv7) instead of sequential QEMU emulation
- Merge job creates multi-arch manifests on both GHCR and DockerHub
- Stable and dev workflows are now thin callers passing config (tag names, cache toggle)
- Bump `build-push-action` from v5 to v6

## Test plan
- [ ] Trigger a dev build (RC tag) and verify all 3 platform jobs run in parallel
- [ ] Verify multi-arch manifest is created on GHCR with both `dev` and version tags
- [ ] Verify DockerHub manifest is created when `DOCKERHUB_ORGANIZATION` is set
- [ ] Trigger a stable build (release tag) and verify same behavior with `latest` tag and no cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)