### PR TITLE
Bump all GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
@@ -62,7 +62,7 @@ jobs:
         if: success() || failure()
 
       - name: Surface failing tests
-        uses: pmeier/pytest-results-action@main
+        uses: pmeier/pytest-results-action@v0.7.2
         with:
           title: Test results (Python ${{ matrix.python-version }})
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -40,33 +40,31 @@ jobs:
           - linux/arm64
           - linux/arm/v7
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set platform slug
         id: platform
         run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
+      - name: Set repository lowercase
+        id: repo
+        run: echo "lowercase=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - id: lowercase-repository
-        name: Lowercase repository
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ github.repository }}
-
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: |
@@ -77,7 +75,7 @@ jobs:
           cache-from: ${{ inputs.use-cache && 'type=gha' || '' }}
           cache-to: ${{ inputs.use-cache && 'type=gha,mode=max' || '' }}
           tags: |
-            ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}-${{ steps.platform.outputs.slug }}
+            ghcr.io/${{ steps.repo.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}-${{ steps.platform.outputs.slug }}
 
   merge:
     runs-on: ubuntu-latest
@@ -86,32 +84,30 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION == null && secrets.DOCKERHUB_USERNAME || secrets.DOCKERHUB_ORGANIZATION }}
     steps:
-      - id: lowercase-repository
-        name: Lowercase repository
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ github.repository }}
+      - name: Set repository lowercase
+        id: repo
+        run: echo "lowercase=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: env.DOCKERHUB_USERNAME != null
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Create GHCR multi-arch manifest
         run: |
-          GHCR_BASE="ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
+          GHCR_BASE="ghcr.io/${{ steps.repo.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
           for tag in "${{ inputs.image-tag }}" "${{ inputs.version-tag }}"; do
             docker buildx imagetools create -t "${GHCR_BASE}:${tag}" \
               "${GHCR_BASE}:${{ inputs.image-tag }}-linux-amd64" \
@@ -122,7 +118,7 @@ jobs:
       - name: Create DockerHub multi-arch manifest
         if: env.DOCKERHUB_ORGANIZATION != null
         run: |
-          GHCR_BASE="ghcr.io/${{ steps.lowercase-repository.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
+          GHCR_BASE="ghcr.io/${{ steps.repo.outputs.lowercase }}/${{ env.IMAGE_NAME }}"
           DH_BASE="${{ env.DOCKERHUB_ORGANIZATION }}/${{ env.DOCKERHUB_IMAGE_NAME }}"
           for tag in "${{ inputs.image-tag }}" "${{ inputs.version-tag }}"; do
             docker buildx imagetools create -t "${DH_BASE}:${tag}" \


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to latest major versions with Node 24 support
- Replace `ASzc/change-string-case-action` (stuck on Node 20) with bash `${GITHUB_REPOSITORY,,}`
- Pin `pmeier/pytest-results-action` from `@main` to `v0.7.2` for stability

### Docker workflows (`build_docker_images.yml`)
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `ASzc/change-string-case-action` | v6 | removed |

### Test workflow (`build_and_test_python.yml`)
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/cache` | v4 | v5 |
| `pmeier/pytest-results-action` | @main | v0.7.2 |

## Test plan
- [ ] Verify test workflow runs without Node.js 20 deprecation warnings
- [ ] Verify Docker build workflow runs without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)