### PR TITLE
Replace pmeier/pytest-results-action with mikepenz/action-junit-report

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -62,17 +62,9 @@ jobs:
         if: success() || failure()
 
       - name: Surface failing tests
-        uses: pmeier/pytest-results-action@v0.7.2
+        uses: mikepenz/action-junit-report@v6
+        if: always()
         with:
-          title: Test results (Python ${{ matrix.python-version }})
-          path: junit/test-results-${{ matrix.python-version }}.xml
-
-          # (Optional) Add a summary of the results at the top of the report
-          summary: true
-          # (Optional) Select which results should be included in the report.
-          # Follows the same syntax as `pytest -r`
-          display-options: fEX
-
-          # (Optional) Fail the workflow if no JUnit XML was found.
-          fail-on-empty: true
-        if: ${{ always() }}
+          report_paths: junit/test-results-${{ matrix.python-version }}.xml
+          check_name: Test results (Python ${{ matrix.python-version }})
+          require_tests: true

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '*'
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary
- Replace `pmeier/pytest-results-action` (Node 20) with `mikepenz/action-junit-report@v6` (Node 24)
- Eliminates the last remaining Node 20 dependency across all workflows

## Test plan
- [ ] Verify test results still appear as PR check annotations
- [ ] Verify `require_tests: true` fails the check if no JUnit XML is found

🤖 Generated with [Claude Code](https://claude.com/claude-code)