### PR TITLE
fix: remove incorrect state_class from CCU plug status sensors

### DIFF
--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -457,14 +457,12 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
         self._publish_sensor(
             mqtt_topics.CCU_ONBOARD_PLUG_STATUS,
             "CCU Onboard Plug Status",
-            state_class="measurement",
             entity_category="diagnostic",
             enabled=False,
         )
         self._publish_sensor(
             mqtt_topics.CCU_OFFBOARD_PLUG_STATUS,
             "CCU Offboard Plug Status",
-            state_class="measurement",
             entity_category="diagnostic",
             enabled=False,
         )


### PR DESCRIPTION
## Summary
- Remove `state_class="measurement"` from CCU Onboard/Offboard Plug Status sensors
- These are status codes, not numeric measurements — `state_class` without `unit_of_measurement` is invalid in HA

## Test plan
- [ ] Verify CCU plug status sensors still appear correctly in HA
- [ ] Confirm no HA warnings about invalid sensor configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)