### PR TITLE
fix: improve ABRP and OsmAnd integration error handling and cleanup

### DIFF
--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -122,9 +122,11 @@ class VehicleHandler:
         )
 
     async def close(self) -> None:
-        await self.abrp_api.close()
-        if self.osmand_api is not None:
-            await self.osmand_api.close()
+        try:
+            await self.abrp_api.close()
+        finally:
+            if self.osmand_api is not None:
+                await self.osmand_api.close()
 
     async def handle_vehicle(self) -> None:
         start_time = datetime.datetime.now()

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -121,6 +121,11 @@ class VehicleHandler:
             listener=api_listener,
         )
 
+    async def close(self) -> None:
+        await self.abrp_api.close()
+        if self.osmand_api is not None:
+            await self.osmand_api.close()
+
     async def handle_vehicle(self) -> None:
         start_time = datetime.datetime.now()
         self.__vehicle_info_publisher.publish()

--- a/src/integrations/abrp/api.py
+++ b/src/integrations/abrp/api.py
@@ -135,20 +135,20 @@ class AbrpApi:
                     headers=headers,
                     params={"token": self.abrp_user_token, "tlm": json.dumps(data)},
                 )
-                await response.aread()
+                response.raise_for_status()
                 return True, response.text
-            except httpx.ConnectError as ece:
-                msg = f"Connection error: {ece}"
-                raise AbrpApiException(msg) from ece
-            except httpx.TimeoutException as et:
-                msg = f"Timeout error {et}"
-                raise AbrpApiException(msg) from et
-            except httpx.RequestError as e:
-                msg = f"{e}"
+            except httpx.ConnectError as e:
+                msg = f"Connection error: {e}"
                 raise AbrpApiException(msg) from e
-            except httpx.HTTPError as ehttp:
-                msg = f"HTTP error {ehttp}"
-                raise AbrpApiException(msg) from ehttp
+            except httpx.TimeoutException as e:
+                msg = f"Timeout error: {e}"
+                raise AbrpApiException(msg) from e
+            except httpx.HTTPStatusError as e:
+                msg = f"HTTP {e.response.status_code} error: {e}"
+                raise AbrpApiException(msg) from e
+            except httpx.HTTPError as e:
+                msg = f"HTTP error: {e}"
+                raise AbrpApiException(msg) from e
         else:
             return False, "ABRP request skipped because of missing configuration"
 

--- a/src/integrations/abrp/api.py
+++ b/src/integrations/abrp/api.py
@@ -63,6 +63,9 @@ class AbrpApi:
             }
         )
 
+    async def close(self) -> None:
+        await self.client.aclose()
+
     async def update_abrp(
         self,
         vehicle_status: VehicleStatusResp | None,

--- a/src/integrations/osmand/api.py
+++ b/src/integrations/osmand/api.py
@@ -122,20 +122,20 @@ class OsmAndApi:
 
             try:
                 response = await self.client.post(url=self.__server_uri, params=data)
-                await response.aread()
+                response.raise_for_status()
                 return True, response.text
-            except httpx.ConnectError as ece:
-                msg = f"Connection error: {ece}"
-                raise OsmAndApiException(msg) from ece
-            except httpx.TimeoutException as et:
-                msg = f"Timeout error {et}"
-                raise OsmAndApiException(msg) from et
-            except httpx.RequestError as e:
-                msg = f"{e}"
+            except httpx.ConnectError as e:
+                msg = f"Connection error: {e}"
                 raise OsmAndApiException(msg) from e
-            except httpx.HTTPError as ehttp:
-                msg = f"HTTP error {ehttp}"
-                raise OsmAndApiException(msg) from ehttp
+            except httpx.TimeoutException as e:
+                msg = f"Timeout error: {e}"
+                raise OsmAndApiException(msg) from e
+            except httpx.HTTPStatusError as e:
+                msg = f"HTTP {e.response.status_code} error: {e}"
+                raise OsmAndApiException(msg) from e
+            except httpx.HTTPError as e:
+                msg = f"HTTP error: {e}"
+                raise OsmAndApiException(msg) from e
         else:
             return False, "OsmAnd request skipped because of missing configuration"
 

--- a/src/integrations/osmand/api.py
+++ b/src/integrations/osmand/api.py
@@ -64,6 +64,9 @@ class OsmAndApi:
             }
         )
 
+    async def close(self) -> None:
+        await self.client.aclose()
+
     async def update_osmand(
         self,
         vehicle_status: VehicleStatusResp | None,

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from asyncio import Task
+import contextlib
 import datetime
 import logging
 from random import uniform
@@ -318,10 +319,8 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
             vh.vehicle_state.mark_failed_refresh()
             task = self.__cancel_vehicle_task(vin)
             if task is not None:
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
             await vh.close()
 
     def __start_vehicle_task(self, vh: VehicleHandler) -> None:

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -317,6 +317,7 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
             vh = self.vehicle_handlers.pop(vin)
             vh.vehicle_state.mark_failed_refresh()
             self.__cancel_vehicle_task(vin)
+            await vh.close()
 
     def __start_vehicle_task(self, vh: VehicleHandler) -> None:
         vin = vh.vin_info.vin
@@ -326,9 +327,13 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
 
     def __cancel_vehicle_task(self, vin: str) -> None:
         task_name = f"handle_vehicle_{vin}"
+        remaining = []
         for t in self.__vehicle_tasks:
             if t.get_name() == task_name:
                 t.cancel()
+            else:
+                remaining.append(t)
+        self.__vehicle_tasks = remaining
 
     @override
     def get_vehicle_handler(self, vin: str) -> VehicleHandler | None:

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -316,7 +316,12 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
             LOG.warning("Vehicle %s no longer in API vehicle list, stopping", vin)
             vh = self.vehicle_handlers.pop(vin)
             vh.vehicle_state.mark_failed_refresh()
-            self.__cancel_vehicle_task(vin)
+            task = self.__cancel_vehicle_task(vin)
+            if task is not None:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
             await vh.close()
 
     def __start_vehicle_task(self, vh: VehicleHandler) -> None:
@@ -325,15 +330,18 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
         self.__vehicle_tasks.append(task)
         LOG.info("Started polling task for vehicle %s", vin)
 
-    def __cancel_vehicle_task(self, vin: str) -> None:
+    def __cancel_vehicle_task(self, vin: str) -> Task[Any] | None:
         task_name = f"handle_vehicle_{vin}"
+        cancelled_task = None
         remaining = []
         for t in self.__vehicle_tasks:
             if t.get_name() == task_name:
                 t.cancel()
+                cancelled_task = t
             else:
                 remaining.append(t)
         self.__vehicle_tasks = remaining
+        return cancelled_task
 
     @override
     def get_vehicle_handler(self, vin: str) -> VehicleHandler | None:

--- a/tests/integrations/abrp/test_abrp_api.py
+++ b/tests/integrations/abrp/test_abrp_api.py
@@ -10,12 +10,15 @@ from tests.common_mocks import (
     get_mock_vehicle_status_resp,
 )
 
+MOCK_API_KEY = "test_api_key"
+MOCK_USER_TOKEN = "test_user_token"
+
 
 class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.api = AbrpApi(
-            abrp_api_key="test_key",
-            abrp_user_token="test_token",
+            abrp_api_key=MOCK_API_KEY,
+            abrp_user_token=MOCK_USER_TOKEN,
         )
         self.vehicle_status = get_mock_vehicle_status_resp()
         self.charge_info = get_mock_charge_management_data_resp()
@@ -23,11 +26,15 @@ class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self) -> None:
         await self.api.close()
 
-    async def test_raise_for_status_on_server_error(self) -> None:
+    async def _set_mock_transport(self, status_code: int, text: str) -> None:
+        await self.api.client.aclose()
         transport = httpx.MockTransport(
-            lambda request: httpx.Response(500, text="Internal Server Error")
+            lambda request: httpx.Response(status_code, text=text)
         )
         self.api.client = httpx.AsyncClient(transport=transport)
+
+    async def test_raise_for_status_on_server_error(self) -> None:
+        await self._set_mock_transport(500, "Internal Server Error")
 
         with self.assertRaises(AbrpApiException) as ctx:
             await self.api.update_abrp(
@@ -37,10 +44,7 @@ class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
         self.assertIn("500", str(ctx.exception))
 
     async def test_raise_for_status_on_client_error(self) -> None:
-        transport = httpx.MockTransport(
-            lambda request: httpx.Response(403, text="Forbidden")
-        )
-        self.api.client = httpx.AsyncClient(transport=transport)
+        await self._set_mock_transport(403, "Forbidden")
 
         with self.assertRaises(AbrpApiException) as ctx:
             await self.api.update_abrp(
@@ -50,10 +54,7 @@ class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
         self.assertIn("403", str(ctx.exception))
 
     async def test_success_on_200(self) -> None:
-        transport = httpx.MockTransport(
-            lambda request: httpx.Response(200, text='{"status": "ok"}')
-        )
-        self.api.client = httpx.AsyncClient(transport=transport)
+        await self._set_mock_transport(200, '{"status": "ok"}')
 
         success, response = await self.api.update_abrp(
             vehicle_status=self.vehicle_status,
@@ -64,7 +65,7 @@ class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
 
     async def test_skips_when_missing_config(self) -> None:
         api = AbrpApi(abrp_api_key=None, abrp_user_token=None)
-        success, response = await api.update_abrp(
+        success, _response = await api.update_abrp(
             vehicle_status=self.vehicle_status,
             charge_info=self.charge_info,
         )

--- a/tests/integrations/abrp/test_abrp_api.py
+++ b/tests/integrations/abrp/test_abrp_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+import httpx
+
+from integrations.abrp.api import AbrpApi, AbrpApiException
+from tests.common_mocks import (
+    get_mock_charge_management_data_resp,
+    get_mock_vehicle_status_resp,
+)
+
+
+class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.api = AbrpApi(
+            abrp_api_key="test_key",
+            abrp_user_token="test_token",
+        )
+        self.vehicle_status = get_mock_vehicle_status_resp()
+        self.charge_info = get_mock_charge_management_data_resp()
+
+    async def asyncTearDown(self) -> None:
+        await self.api.close()
+
+    async def test_raise_for_status_on_server_error(self) -> None:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(500, text="Internal Server Error")
+        )
+        self.api.client = httpx.AsyncClient(transport=transport)
+
+        with self.assertRaises(AbrpApiException) as ctx:
+            await self.api.update_abrp(
+                vehicle_status=self.vehicle_status,
+                charge_info=self.charge_info,
+            )
+        self.assertIn("500", str(ctx.exception))
+
+    async def test_raise_for_status_on_client_error(self) -> None:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(403, text="Forbidden")
+        )
+        self.api.client = httpx.AsyncClient(transport=transport)
+
+        with self.assertRaises(AbrpApiException) as ctx:
+            await self.api.update_abrp(
+                vehicle_status=self.vehicle_status,
+                charge_info=self.charge_info,
+            )
+        self.assertIn("403", str(ctx.exception))
+
+    async def test_success_on_200(self) -> None:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(200, text='{"status": "ok"}')
+        )
+        self.api.client = httpx.AsyncClient(transport=transport)
+
+        success, response = await self.api.update_abrp(
+            vehicle_status=self.vehicle_status,
+            charge_info=self.charge_info,
+        )
+        self.assertTrue(success)
+        self.assertEqual(response, '{"status": "ok"}')
+
+    async def test_skips_when_missing_config(self) -> None:
+        api = AbrpApi(abrp_api_key=None, abrp_user_token=None)
+        success, response = await api.update_abrp(
+            vehicle_status=self.vehicle_status,
+            charge_info=self.charge_info,
+        )
+        self.assertFalse(success)
+        await api.close()

--- a/tests/integrations/abrp/test_abrp_api.py
+++ b/tests/integrations/abrp/test_abrp_api.py
@@ -1,73 +1,107 @@
 from __future__ import annotations
 
-import unittest
+from typing import TYPE_CHECKING
 
 import httpx
+import pytest
+import pytest_asyncio
 
 from integrations.abrp.api import AbrpApi, AbrpApiException
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from saic_ismart_client_ng.api.vehicle import VehicleStatusResp
+    from saic_ismart_client_ng.api.vehicle_charging import ChrgMgmtDataResp
 from tests.common_mocks import (
     get_mock_charge_management_data_resp,
     get_mock_vehicle_status_resp,
 )
 
-MOCK_API_KEY = "test_api_key"
-MOCK_USER_TOKEN = "test_user_token"
+
+@pytest.fixture
+def vehicle_status() -> VehicleStatusResp:
+    return get_mock_vehicle_status_resp()
 
 
-class TestAbrpApi(unittest.IsolatedAsyncioTestCase):
-    def setUp(self) -> None:
-        self.api = AbrpApi(
-            abrp_api_key=MOCK_API_KEY,
-            abrp_user_token=MOCK_USER_TOKEN,
+@pytest.fixture
+def charge_info() -> ChrgMgmtDataResp:
+    return get_mock_charge_management_data_resp()
+
+
+@pytest_asyncio.fixture
+async def abrp_api() -> AsyncIterator[AbrpApi]:
+    api = AbrpApi(
+        abrp_api_key="test_api_key",
+        abrp_user_token="test_user_token",  # noqa: S106
+    )
+    yield api
+    await api.close()
+
+
+async def _set_mock_transport(api: AbrpApi, status_code: int, text: str) -> None:
+    await api.client.aclose()
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(status_code, text=text)
+    )
+    api.client = httpx.AsyncClient(transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_on_server_error(
+    abrp_api: AbrpApi,
+    vehicle_status: VehicleStatusResp,
+    charge_info: ChrgMgmtDataResp,
+) -> None:
+    await _set_mock_transport(abrp_api, 500, "Internal Server Error")
+
+    with pytest.raises(AbrpApiException, match="500"):
+        await abrp_api.update_abrp(
+            vehicle_status=vehicle_status,
+            charge_info=charge_info,
         )
-        self.vehicle_status = get_mock_vehicle_status_resp()
-        self.charge_info = get_mock_charge_management_data_resp()
 
-    async def asyncTearDown(self) -> None:
-        await self.api.close()
 
-    async def _set_mock_transport(self, status_code: int, text: str) -> None:
-        await self.api.client.aclose()
-        transport = httpx.MockTransport(
-            lambda request: httpx.Response(status_code, text=text)
+@pytest.mark.asyncio
+async def test_raise_for_status_on_client_error(
+    abrp_api: AbrpApi,
+    vehicle_status: VehicleStatusResp,
+    charge_info: ChrgMgmtDataResp,
+) -> None:
+    await _set_mock_transport(abrp_api, 403, "Forbidden")
+
+    with pytest.raises(AbrpApiException, match="403"):
+        await abrp_api.update_abrp(
+            vehicle_status=vehicle_status,
+            charge_info=charge_info,
         )
-        self.api.client = httpx.AsyncClient(transport=transport)
 
-    async def test_raise_for_status_on_server_error(self) -> None:
-        await self._set_mock_transport(500, "Internal Server Error")
 
-        with self.assertRaises(AbrpApiException) as ctx:
-            await self.api.update_abrp(
-                vehicle_status=self.vehicle_status,
-                charge_info=self.charge_info,
-            )
-        self.assertIn("500", str(ctx.exception))
+@pytest.mark.asyncio
+async def test_success_on_200(
+    abrp_api: AbrpApi,
+    vehicle_status: VehicleStatusResp,
+    charge_info: ChrgMgmtDataResp,
+) -> None:
+    await _set_mock_transport(abrp_api, 200, '{"status": "ok"}')
 
-    async def test_raise_for_status_on_client_error(self) -> None:
-        await self._set_mock_transport(403, "Forbidden")
+    success, response = await abrp_api.update_abrp(
+        vehicle_status=vehicle_status,
+        charge_info=charge_info,
+    )
+    assert success
+    assert response == '{"status": "ok"}'
 
-        with self.assertRaises(AbrpApiException) as ctx:
-            await self.api.update_abrp(
-                vehicle_status=self.vehicle_status,
-                charge_info=self.charge_info,
-            )
-        self.assertIn("403", str(ctx.exception))
 
-    async def test_success_on_200(self) -> None:
-        await self._set_mock_transport(200, '{"status": "ok"}')
-
-        success, response = await self.api.update_abrp(
-            vehicle_status=self.vehicle_status,
-            charge_info=self.charge_info,
-        )
-        self.assertTrue(success)
-        self.assertEqual(response, '{"status": "ok"}')
-
-    async def test_skips_when_missing_config(self) -> None:
-        api = AbrpApi(abrp_api_key=None, abrp_user_token=None)
-        success, _response = await api.update_abrp(
-            vehicle_status=self.vehicle_status,
-            charge_info=self.charge_info,
-        )
-        self.assertFalse(success)
-        await api.close()
+@pytest.mark.asyncio
+async def test_skips_when_missing_config(
+    vehicle_status: VehicleStatusResp,
+    charge_info: ChrgMgmtDataResp,
+) -> None:
+    api = AbrpApi(abrp_api_key=None, abrp_user_token=None)
+    success, _response = await api.update_abrp(
+        vehicle_status=vehicle_status,
+        charge_info=charge_info,
+    )
+    assert not success
+    await api.close()


### PR DESCRIPTION
## Summary
- Add `response.raise_for_status()` to both ABRP and OsmAnd API calls — HTTP 4xx/5xx were silently treated as success
- Remove redundant `await response.aread()` calls
- Keep detailed per-error-type logging (connection, timeout, HTTP status code)
- Add `async close()` methods to API clients and `VehicleHandler` for proper `httpx.AsyncClient` cleanup
- Call `vh.close()` when vehicles are removed from the API list
- Fix `__cancel_vehicle_task` to remove cancelled tasks from the list instead of leaving stale entries
- Integration failures remain non-fatal: the vehicle handler loop already catches `IntegrationException`

## Test plan
- [ ] Verify ABRP updates still work with valid credentials
- [ ] Verify OsmAnd updates still work with valid server
- [ ] Confirm a 4xx/5xx response is logged with the status code and does not crash the gateway
- [ ] Verify vehicle removal cleans up HTTP clients and removes tasks from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)