### PR TITLE
fix: use maxsplit=1 in string split operations

### DIFF
--- a/src/configuration/argparse_extensions.py
+++ b/src/configuration/argparse_extensions.py
@@ -83,9 +83,7 @@ def cfg_value_to_dict(
 
     for entry in map_entries:
         if "=" in entry:
-            key_value_pair = entry.split("=")
-            key = key_value_pair[0]
-            value = key_value_pair[1]
+            key, value = entry.split("=", maxsplit=1)
             result_map[key] = value_type(value)
 
 

--- a/src/handlers/command/drivetrain/drivetrain_battery_heating.py
+++ b/src/handlers/command/drivetrain/drivetrain_battery_heating.py
@@ -23,12 +23,12 @@ class DrivetrainBatteryHeatingCommand(BooleanCommandHandler[ChrgPtcHeatResp]):
 
     @override
     async def handle_true(self) -> ChrgPtcHeatResp:
-        LOG.info("Battery heater wil be will be switched on")
+        LOG.info("Battery heater will be switched on")
         return await self.saic_api.control_battery_heating(self.vin, enable=True)
 
     @override
     async def handle_false(self) -> ChrgPtcHeatResp:
-        LOG.info("Battery heater wil be will be switched off")
+        LOG.info("Battery heater will be switched off")
         return await self.saic_api.control_battery_heating(self.vin, enable=False)
 
     @override

--- a/src/publisher/core.py
+++ b/src/publisher/core.py
@@ -146,8 +146,6 @@ class Publisher(ABC):
                             | "event-id"
                             | "event_id"
                             | "eventId"
-                            | "event_id"
-                            | "eventID"
                             | "lastKeySeen"
                         ):
                             data[key] = 9999
@@ -170,8 +168,10 @@ class Publisher(ABC):
         return re.sub("[1-9]", "9", r)
 
     def anonymize_device_id(self, device_id: str) -> str:
-        elements = device_id.split("###")
-        return f"{self.anonymize_str(elements[0])}###{self.anonymize_str(elements[1])}"
+        elements = device_id.split("###", maxsplit=1)
+        if len(elements) == 2:
+            return f"{self.anonymize_str(elements[0])}###{self.anonymize_str(elements[1])}"
+        return self.anonymize_str(device_id)
 
     @staticmethod
     def anonymize_int(value: int) -> int:

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -70,5 +70,19 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
     async def send_message(self, topic: str, payload: Any) -> None:
         await self.mqtt_client.client.on_message("client", topic, payload, 0, {})
 
+    async def test_get_vin_from_sanitized_topic(self) -> None:
+        """Topics arrive with the sanitized prefix, not the raw username."""
+        sanitized_prefix = self.mqtt_client.get_mqtt_account_prefix()
+        topic = f"{sanitized_prefix}/vehicles/{VIN}/refresh/mode/set"
+        await self.send_message(topic, MODE)
+        assert self.received_vin == VIN
+        assert self.received_payload == MODE
+
+    def test_get_vin_from_topic_uses_sanitized_prefix(self) -> None:
+        """get_vin_from_topic should work with sanitized topics."""
+        sanitized_prefix = self.mqtt_client.get_mqtt_account_prefix()
+        topic = f"{sanitized_prefix}/vehicles/{VIN}/refresh/mode/set"
+        assert self.mqtt_client.get_vin_from_topic(topic) == VIN
+
     async def on_charging_detected(self, vin: str) -> None:
         pass


### PR DESCRIPTION
## Summary
- Fix `anonymize_device_id` crash (IndexError) when a `deviceId` lacks the `"###"` separator — now falls back to anonymizing the whole string
- Fix `cfg_value_to_dict` to use `split("=", maxsplit=1)` so values containing `=` (e.g. base64 tokens) are not truncated
- Remove duplicate match arms (`eventID`, `event_id`) in `__anonymize`
- Add test for `get_vin_from_topic` with sanitized prefix
- Investigated #8 (`get_vin_from_topic` sanitized prefix) — not a real bug since char replacement is 1:1, but added test coverage
- Fix typo in battery heating log messages ("wil be will be" → "will be")

## Test plan
- [ ] Verify anonymized publishing still works with normal device IDs
- [ ] Test config values containing `=` are parsed correctly (e.g. ABRP tokens)
- [ ] Verify battery heating command log messages are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)