### PR TITLE
fix: standardize on UTC-aware datetimes in vehicle.py

### DIFF
--- a/src/handlers/message.py
+++ b/src/handlers/message.py
@@ -28,7 +28,7 @@ class MessageHandler:
         self.gateway = gateway
         self.saicapi = saicapi
         self.relogin_handler = relogin_handler
-        self.last_message_ts = datetime.datetime.min
+        self.last_message_ts = datetime.datetime.min.replace(tzinfo=datetime.UTC)
         self.last_message_id: str | int | None = None
 
     async def check_for_new_messages(self) -> None:

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -122,7 +122,7 @@ class VehicleHandler:
         )
 
     async def handle_vehicle(self) -> None:
-        start_time = datetime.datetime.now()
+        start_time = datetime.datetime.now(tz=datetime.UTC)
         self.__vehicle_info_publisher.publish()
         self.vehicle_state.notify_car_activity()
 
@@ -229,7 +229,7 @@ class VehicleHandler:
     def __should_complete_configuration(self, start_time: datetime.datetime) -> bool:
         return (
             not self.vehicle_state.is_complete()
-            and datetime.datetime.now() > start_time + datetime.timedelta(seconds=10)
+            and datetime.datetime.now(tz=datetime.UTC) > start_time + datetime.timedelta(seconds=10)
         )
 
     def __refresh_openwb(

--- a/src/status_publisher/charge/chrg_mgmt_data_resp.py
+++ b/src/status_publisher/charge/chrg_mgmt_data_resp.py
@@ -79,7 +79,7 @@ class ChrgMgmtDataRespPublisher(
         if chrg_mgmt_data_result is not None or charge_status_result is not None:
             self._publish(
                 topic=mqtt_topics.REFRESH_LAST_CHARGE_STATE,
-                value=datetime.datetime.now(),
+                value=datetime.datetime.now(tz=datetime.UTC),
             )
         return ChrgMgmtDataRespProcessingResult(
             charge_current_limit=chrg_mgmt_data_result.charge_current_limit

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, override
 
 from saic_ismart_client_ng.api.message import MessageEntity
@@ -26,12 +26,12 @@ class MessagePublisher(
         self, vin: VehicleInfo, publisher: Publisher, mqtt_vehicle_prefix: str
     ) -> None:
         super().__init__(vin, publisher, mqtt_vehicle_prefix)
-        self.__last_car_vehicle_message = datetime.min
+        self.__last_car_vehicle_message = datetime.min.replace(tzinfo=UTC)
 
     @override
     def publish(self, message: MessageEntity) -> MessagePublisherProcessingResult:
         if (
-            self.__last_car_vehicle_message == datetime.min
+            self.__last_car_vehicle_message == datetime.min.replace(tzinfo=UTC)
             or message.message_time > self.__last_car_vehicle_message
         ):
             self.__last_car_vehicle_message = message.message_time

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -84,7 +84,7 @@ class VehicleStatusRespPublisher(
 
         self._publish(
             topic=mqtt_topics.REFRESH_LAST_VEHICLE_STATE,
-            value=datetime.datetime.now(),
+            value=datetime.datetime.now(tz=datetime.UTC),
         )
 
         return VehicleStatusRespProcessingResult(

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -84,13 +84,13 @@ class VehicleState:
         )
         self.vehicle: Final[VehicleInfo] = vin_info
         self.mqtt_vin_prefix = account_prefix
-        self.last_car_activity: datetime.datetime = datetime.datetime.min
-        self.last_successful_refresh: datetime.datetime = datetime.datetime.min
+        self.last_car_activity: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
+        self.last_successful_refresh: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
         self.__last_failed_refresh: datetime.datetime | None = None
         self.__failed_refresh_counter = 0
         self.__refresh_period_error = 30
-        self.last_car_shutdown: datetime.datetime = datetime.datetime.now()
-        self.last_car_vehicle_message: datetime.datetime = datetime.datetime.min
+        self.last_car_shutdown: datetime.datetime = datetime.datetime.now(tz=datetime.UTC)
+        self.last_car_vehicle_message: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
         # treat high voltage battery as active, if we don't have any other information
         self.__hv_battery_active = True
         self.__hv_battery_active_from_car = True
@@ -306,14 +306,14 @@ class VehicleState:
     def hv_battery_active_from_car(self, new_state: bool) -> None:
         old_state = self.__hv_battery_active_from_car
         if old_state and not new_state:
-            self.last_car_shutdown = datetime.datetime.now()
+            self.last_car_shutdown = datetime.datetime.now(tz=datetime.UTC)
             LOG.info(
                 f"Detected vehicle {self.vin} shutdown at {self.last_car_shutdown}"
             )
         self.__hv_battery_active_from_car = new_state
 
     def notify_car_activity(self) -> None:
-        self.last_car_activity = datetime.datetime.now()
+        self.last_car_activity = datetime.datetime.now(tz=datetime.UTC)
         self.__publish(
             topic=mqtt_topics.REFRESH_LAST_ACTIVITY,
             value=datetime_to_str(self.last_car_activity),
@@ -355,7 +355,7 @@ class VehicleState:
             )
             return True
         if self.last_failed_refresh is not None:
-            threshold = datetime.datetime.now() - datetime.timedelta(
+            threshold = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
                 seconds=float(self.refresh_period_error)
             )
             result: bool = self.last_failed_refresh < threshold
@@ -364,7 +364,7 @@ class VehicleState:
         if self.is_charging and self.refresh_period_charging > 0:
             result = (
                 self.last_successful_refresh
-                < datetime.datetime.now()
+                < datetime.datetime.now(tz=datetime.UTC)
                 - datetime.timedelta(seconds=float(self.refresh_period_charging))
             )
             LOG.debug(f"HV battery is charging. Should refresh: {result}")
@@ -372,7 +372,7 @@ class VehicleState:
         if self.hv_battery_active:
             result = (
                 self.last_successful_refresh
-                < datetime.datetime.now()
+                < datetime.datetime.now(tz=datetime.UTC)
                 - datetime.timedelta(seconds=float(self.refresh_period_active))
             )
             LOG.debug(f"HV battery is active. Should refresh: {result}")
@@ -380,10 +380,10 @@ class VehicleState:
         last_shutdown_plus_refresh = self.last_car_shutdown + datetime.timedelta(
             seconds=float(self.refresh_period_inactive_grace)
         )
-        if last_shutdown_plus_refresh > datetime.datetime.now():
+        if last_shutdown_plus_refresh > datetime.datetime.now(tz=datetime.UTC):
             result = (
                 self.last_successful_refresh
-                < datetime.datetime.now()
+                < datetime.datetime.now(tz=datetime.UTC)
                 - datetime.timedelta(seconds=float(self.refresh_period_after_shutdown))
             )
             LOG.debug(
@@ -392,7 +392,7 @@ class VehicleState:
             return result
         result = (
             self.last_successful_refresh
-            < datetime.datetime.now()
+            < datetime.datetime.now(tz=datetime.UTC)
             - datetime.timedelta(seconds=float(self.refresh_period_inactive))
         )
         LOG.debug(
@@ -401,12 +401,12 @@ class VehicleState:
         return result
 
     def mark_successful_refresh(self) -> None:
-        self.last_successful_refresh = datetime.datetime.now()
+        self.last_successful_refresh = datetime.datetime.now(tz=datetime.UTC)
         self.last_failed_refresh = None
         self.publisher.publish_str(self.get_topic(mqtt_topics.AVAILABLE), "online")
 
     def mark_failed_refresh(self) -> None:
-        self.last_failed_refresh = datetime.datetime.now()
+        self.last_failed_refresh = datetime.datetime.now(tz=datetime.UTC)
         self.publisher.publish_str(self.get_topic(mqtt_topics.AVAILABLE), "offline")
 
     @property


### PR DESCRIPTION
## Summary
- Replace all naive `datetime.datetime.now()` calls with `datetime.datetime.now(tz=datetime.UTC)` across the codebase
- Initialize sentinel datetime values (`last_car_activity`, `last_successful_refresh`, `last_car_vehicle_message`, `last_message_ts`) with `.replace(tzinfo=datetime.UTC)` instead of naive `datetime.min`
- Prevents `TypeError: can't compare offset-naive and offset-aware datetimes` when any code path introduces a timezone-aware datetime

### Files changed
- `src/vehicle.py` — all refresh scheduling and activity tracking datetimes
- `src/handlers/vehicle.py` — configuration startup timer
- `src/handlers/message.py` — message polling sentinel
- `src/status_publisher/message.py` — last vehicle message sentinel
- `src/status_publisher/charge/chrg_mgmt_data_resp.py` — published charge state timestamp
- `src/status_publisher/vehicle/vehicle_status_resp.py` — published vehicle state timestamp

## Test plan
- [ ] Verify vehicle refresh logic works correctly (periodic refresh, charging refresh, shutdown grace period)
- [ ] Confirm no `TypeError` on datetime comparisons in logs
- [ ] Verify MQTT timestamps for last charge/vehicle state are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)