### PR TITLE
fix: miscellaneous code quality and test fixes

### DIFF
--- a/src/handlers/command/climate/climate_front_window_heat.py
+++ b/src/handlers/command/climate/climate_front_window_heat.py
@@ -26,7 +26,7 @@ class ClimateFrontWindowHeatCommand(BooleanCommandHandler[None]):
 
     @override
     async def handle_false(self) -> None:
-        LOG.info("Front window heating will be switched off")
+        LOG.info("AC will be stopped (no dedicated front defrost stop API available)")
         await self.saic_api.stop_ac(self.vin)
 
     @override

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -332,6 +332,7 @@ class VehicleHandler:
 
 
 class VehicleHandlerLocator(ABC):
+    @abstractmethod
     def get_vehicle_handler(self, vin: str) -> VehicleHandler | None:
         raise NotImplementedError
 

--- a/tests/handlers/command/test_command_compatibility.py
+++ b/tests/handlers/command/test_command_compatibility.py
@@ -27,10 +27,10 @@ def test_all_commands_should_have_a_valid_topic(
 
 
 def test_there_should_be_no_duplicate_command_names() -> None:
-    discovered_names = [x.name for x in ALL_COMMAND_HANDLERS]
+    discovered_names = [x.name() for x in ALL_COMMAND_HANDLERS]
     assert len(discovered_names) == len(set(discovered_names))
 
 
 def test_there_should_be_no_duplicate_command_topics() -> None:
-    discovered_names = [x.topic for x in ALL_COMMAND_HANDLERS]
+    discovered_names = [x.topic() for x in ALL_COMMAND_HANDLERS]
     assert len(discovered_names) == len(set(discovered_names))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,4 +6,3 @@ from configuration.parser import setup_parser
 def test_setup_parser_should_generate_a_valid_parser() -> None:
     parser = setup_parser()
     parser.print_help()
-    assert True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,10 +105,6 @@ class Test(TestCase):
 
         result = get_update_timestamp(vehicle_status_resp)
 
-        assert int(result.timestamp()) is not None, (
-            "This test should have returned a timestamp"
-        )
-
         assert result <= datetime.datetime.now(tz=datetime.UTC)
 
     def test_get_update_should_return_now_if_no_other_info_is_there_v3(self) -> None:
@@ -120,9 +116,5 @@ class Test(TestCase):
         )
 
         result = get_update_timestamp(vehicle_status_resp)
-
-        assert int(result.timestamp()) is not None, (
-            "This test should have returned a timestamp"
-        )
 
         assert result <= datetime.datetime.now(tz=datetime.UTC)


### PR DESCRIPTION
## Summary
- Add missing `@abstractmethod` to `VehicleHandlerLocator.get_vehicle_handler` so Python enforces implementation in subclasses
- Fix front defroster off log message — `handle_false` calls `stop_ac()` (no dedicated defrost-stop API exists), log now reflects this
- Remove always-true `assert int(...) is not None` assertions in `test_utils.py`
- Remove meaningless `assert True` in `test_parser.py` (test validates `print_help()` doesn't crash, assertion adds nothing)
- Fix `test_command_compatibility.py` duplicate-name/topic checks to call `x.name()` / `x.topic()` instead of comparing unbound method references
- Rename `test_command_compatibiltiy.py` → `test_command_compatibility.py` (typo)

## Test plan
- [ ] All existing tests pass
- [ ] Verify duplicate command name/topic tests now actually validate string uniqueness

🤖 Generated with [Claude Code](https://claude.com/claude-code)