### PR TITLE
feat: add SoC timestamp support for openWB

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The key-value pairs in the JSON express the following:
 | chargeStateTopic      | topic indicating the charge state - **required**                                                  |
 | chargingValue         | payload that indicates the charging - **required**                                                |
 | socTopic              | topic where the gateway publishes the SoC for the charging station - optional                     |
+| socTsTopic            | topic where the gateway publishes the SoC timestamp for the charging station - optional           |
 | rangeTopic            | topic where the gateway publishes the range for the charging station - optional                   |
 | chargerConnectedTopic | topic indicating that the vehicle is connected to the charging station - optional                 |
 | chargerConnectedValue | payload that indicates that the charger is connected - optional                                   |

--- a/examples/charging-stations.json.sample_openWB_2.0
+++ b/examples/charging-stations.json.sample_openWB_2.0
@@ -2,8 +2,9 @@
     {
         "chargeStateTopic": "openWB/chargepoint/2/get/charge_state",
         "chargingValue": "true",
-        "socTopic": "openWB/set/vehicle/2/get/soc",
-        "rangeTopic": "openWB/set/vehicle/2/get/range",
+        "socTopic": "openWB/set/mqtt/vehicle/2/get/soc",
+        "socTsTopic": "openWB/set/mqtt/vehicle/2/get/soc_timestamp",
+        "rangeTopic": "openWB/set/mqtt/vehicle/2/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/2/get/plug_state",
         "chargerConnectedValue": "true",
         "vin": "vin1"
@@ -11,8 +12,9 @@
     {
         "chargeStateTopic": "openWB/chargepoint/3/get/charge_state",
         "chargingValue": "true",
-        "socTopic": "openWB/set/vehicle/3/get/soc",
-        "rangeTopic": "openWB/set/vehicle/3/get/range",
+        "socTopic": "openWB/set/mqtt/vehicle/3/get/soc",
+        "socTsTopic": "openWB/set/mqtt/vehicle/3/get/soc_timestamp",
+        "rangeTopic": "openWB/set/mqtt/vehicle/3/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/3/get/plug_state",
         "chargerConnectedValue": "true",
         "vin": "vin2"

--- a/src/configuration/parser.py
+++ b/src/configuration/parser.py
@@ -566,11 +566,11 @@ def __process_charging_stations_file(config: Configuration, json_file: str) -> N
                 soc_ts_topic = item.get("socTsTopic")
                 vin = item["vin"]
                 charging_station = ChargingStation(
-                    vin,
-                    charge_state_topic,
-                    charging_value,
-                    soc_topic,
-                    soc_ts_topic,
+                    vin=vin,
+                    charge_state_topic=charge_state_topic,
+                    charging_value=charging_value,
+                    soc_topic=soc_topic,
+                    soc_ts_topic=soc_ts_topic,
                 )
                 if "rangeTopic" in item:
                     charging_station.range_topic = item["rangeTopic"]

--- a/src/configuration/parser.py
+++ b/src/configuration/parser.py
@@ -562,15 +562,16 @@ def __process_charging_stations_file(config: Configuration, json_file: str) -> N
             for item in data:
                 charge_state_topic = item["chargeStateTopic"]
                 charging_value = item["chargingValue"]
+                soc_topic = item.get("socTopic")
+                soc_ts_topic = item.get("socTsTopic")
                 vin = item["vin"]
-                if "socTopic" in item:
-                    charging_station = ChargingStation(
-                        vin, charge_state_topic, charging_value, item["socTopic"]
-                    )
-                else:
-                    charging_station = ChargingStation(
-                        vin, charge_state_topic, charging_value
-                    )
+                charging_station = ChargingStation(
+                    vin,
+                    charge_state_topic,
+                    charging_value,
+                    soc_topic,
+                    soc_ts_topic,
+                )
                 if "rangeTopic" in item:
                     charging_station.range_topic = item["rangeTopic"]
                 if "chargerConnectedTopic" in item:

--- a/src/configuration/parser.py
+++ b/src/configuration/parser.py
@@ -560,24 +560,17 @@ def __process_charging_stations_file(config: Configuration, json_file: str) -> N
             data = json.load(f)
 
             for item in data:
-                charge_state_topic = item["chargeStateTopic"]
-                charging_value = item["chargingValue"]
-                soc_topic = item.get("socTopic")
-                soc_ts_topic = item.get("socTsTopic")
                 vin = item["vin"]
                 charging_station = ChargingStation(
                     vin=vin,
-                    charge_state_topic=charge_state_topic,
-                    charging_value=charging_value,
-                    soc_topic=soc_topic,
-                    soc_ts_topic=soc_ts_topic,
+                    charge_state_topic=item["chargeStateTopic"],
+                    charging_value=item["chargingValue"],
+                    soc_topic=item.get("socTopic"),
+                    soc_ts_topic=item.get("socTsTopic"),
+                    range_topic=item.get("rangeTopic"),
+                    connected_topic=item.get("chargerConnectedTopic"),
+                    connected_value=item.get("chargerConnectedValue"),
                 )
-                if "rangeTopic" in item:
-                    charging_station.range_topic = item["rangeTopic"]
-                if "chargerConnectedTopic" in item:
-                    charging_station.connected_topic = item["chargerConnectedTopic"]
-                if "chargerConnectedValue" in item:
-                    charging_station.connected_value = item["chargerConnectedValue"]
                 config.charging_stations_by_vin[vin] = charging_station
     except FileNotFoundError:
         LOG.warning(f"File {json_file} does not exist")

--- a/src/integrations/openwb/__init__.py
+++ b/src/integrations/openwb/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 from typing import TYPE_CHECKING
 
@@ -40,7 +41,7 @@ class OpenWBIntegration:
             vehicle_status, charge_status
         )
         if electric_range is not None and range_topic is not None:
-            LOG.info("OpenWB Integration published range to %f", range_topic)
+            LOG.info("OpenWB Integration published range to %s", range_topic)
             self.__publisher.publish_float(
                 key=range_topic,
                 value=electric_range,
@@ -56,3 +57,13 @@ class OpenWBIntegration:
                 value=soc,
                 no_prefix=True,
             )
+
+            soc_ts_topic = self.__charging_station.soc_ts_topic
+            if soc_ts_topic is not None:
+                soc_ts = int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+                LOG.info("OpenWB Integration published SoC timestamp to %s", soc_ts_topic)
+                self.__publisher.publish_int(
+                    key=soc_ts_topic,
+                    value=soc_ts,
+                    no_prefix=True,
+                )

--- a/src/integrations/openwb/charging_station.py
+++ b/src/integrations/openwb/charging_station.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Final
+
 
 class ChargingStation:
     def __init__(
@@ -10,12 +12,15 @@ class ChargingStation:
         charging_value: str,
         soc_topic: str | None = None,
         soc_ts_topic: str | None = None,
+        range_topic: str | None = None,
+        connected_topic: str | None = None,
+        connected_value: str | None = None,
     ) -> None:
-        self.vin: str = vin
-        self.charge_state_topic: str = charge_state_topic
-        self.charging_value: str = charging_value
-        self.soc_topic: str | None = soc_topic
-        self.soc_ts_topic: str | None = soc_ts_topic
-        self.range_topic: str | None = None
-        self.connected_topic: str | None = None
-        self.connected_value: str | None = None
+        self.vin: Final = vin
+        self.charge_state_topic: Final = charge_state_topic
+        self.charging_value: Final = charging_value
+        self.soc_topic: Final = soc_topic
+        self.soc_ts_topic: Final = soc_ts_topic
+        self.range_topic: Final = range_topic
+        self.connected_topic: Final = connected_topic
+        self.connected_value: Final = connected_value

--- a/src/integrations/openwb/charging_station.py
+++ b/src/integrations/openwb/charging_station.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 class ChargingStation:
     def __init__(
         self,
+        *,
         vin: str,
         charge_state_topic: str,
         charging_value: str,

--- a/src/integrations/openwb/charging_station.py
+++ b/src/integrations/openwb/charging_station.py
@@ -8,11 +8,13 @@ class ChargingStation:
         charge_state_topic: str,
         charging_value: str,
         soc_topic: str | None = None,
+        soc_ts_topic: str | None = None,
     ) -> None:
         self.vin: str = vin
         self.charge_state_topic: str = charge_state_topic
         self.charging_value: str = charging_value
         self.soc_topic: str | None = soc_topic
+        self.soc_ts_topic: str | None = soc_ts_topic
         self.range_topic: str | None = None
         self.connected_topic: str | None = None
         self.connected_value: str | None = None

--- a/tests/integrations/openwb/test_openwb_integration.py
+++ b/tests/integrations/openwb/test_openwb_integration.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import datetime
 from typing import Any
 import unittest
+from unittest.mock import patch
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 import pytest
@@ -25,7 +27,10 @@ from vehicle_info import VehicleInfo
 RANGE_TOPIC = "/mock/range"
 CHARGE_STATE_TOPIC = "/mock/charge/state"
 SOC_TOPIC = "/mock/soc/state"
+SOC_TS_TOPIC = "/mock/soc/timestamp"
 CHARGING_VALUE = "VehicleIsCharging"
+
+FROZEN_TIME = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
 
 class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
@@ -46,6 +51,7 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
             charge_state_topic=CHARGE_STATE_TOPIC,
             charging_value=CHARGING_VALUE,
             soc_topic=SOC_TOPIC,
+            soc_ts_topic=SOC_TS_TOPIC,
         )
         charging_station.range_topic = RANGE_TOPIC
         self.openwb_integration = OpenWBIntegration(
@@ -53,7 +59,10 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
             publisher=self.publisher,
         )
 
-    async def test_update_soc_with_no_bms_data(self) -> None:
+    @patch("integrations.openwb.datetime")
+    async def test_update_soc_with_no_bms_data(self, mock_datetime: Any) -> None:
+        mock_datetime.datetime.now.return_value = FROZEN_TIME
+        mock_datetime.timezone = datetime.timezone
         vehicle_status_resp = get_mock_vehicle_status_resp()
         result = self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
 
@@ -66,16 +75,24 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
             float(DRIVETRAIN_SOC_VEHICLE),
         )
         self.assert_mqtt_topic(
+            SOC_TS_TOPIC,
+            int(FROZEN_TIME.timestamp()),
+        )
+        self.assert_mqtt_topic(
             RANGE_TOPIC,
             DRIVETRAIN_RANGE_VEHICLE,
         )
         expected_topics = {
             SOC_TOPIC,
+            SOC_TS_TOPIC,
             RANGE_TOPIC,
         }
         assert expected_topics == set(self.publisher.map.keys())
 
-    async def test_update_soc_with_bms_data(self) -> None:
+    @patch("integrations.openwb.datetime")
+    async def test_update_soc_with_bms_data(self, mock_datetime: Any) -> None:
+        mock_datetime.datetime.now.return_value = FROZEN_TIME
+        mock_datetime.timezone = datetime.timezone
         vehicle_status_resp = get_mock_vehicle_status_resp()
         chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
         vehicle_status_resp_result = self.vehicle_state.handle_vehicle_status(
@@ -98,8 +115,13 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
             RANGE_TOPIC,
             DRIVETRAIN_RANGE_BMS,
         )
+        self.assert_mqtt_topic(
+            SOC_TS_TOPIC,
+            int(FROZEN_TIME.timestamp()),
+        )
         expected_topics = {
             SOC_TOPIC,
+            SOC_TS_TOPIC,
             RANGE_TOPIC,
         }
         assert expected_topics == set(self.publisher.map.keys())

--- a/tests/integrations/openwb/test_openwb_integration.py
+++ b/tests/integrations/openwb/test_openwb_integration.py
@@ -54,8 +54,8 @@ def _make_integration(
         charging_value=CHARGING_VALUE,
         soc_topic=soc_topic,
         soc_ts_topic=soc_ts_topic,
+        range_topic=RANGE_TOPIC,
     )
-    charging_station.range_topic = RANGE_TOPIC
     return OpenWBIntegration(
         charging_station=charging_station,
         publisher=publisher,

--- a/tests/integrations/openwb/test_openwb_integration.py
+++ b/tests/integrations/openwb/test_openwb_integration.py
@@ -33,36 +33,47 @@ CHARGING_VALUE = "VehicleIsCharging"
 FROZEN_TIME = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
 
 
+def _make_vehicle_state(publisher: MessageCapturingConsolePublisher) -> VehicleState:
+    vin_info = VinInfo()
+    vin_info.vin = VIN
+    vehicle_info = VehicleInfo(vin_info, None)
+    account_prefix = f"/vehicles/{VIN}"
+    scheduler = BlockingScheduler()
+    return VehicleState(publisher, scheduler, account_prefix, vehicle_info)
+
+
+def _make_integration(
+    publisher: MessageCapturingConsolePublisher,
+    *,
+    soc_topic: str | None = SOC_TOPIC,
+    soc_ts_topic: str | None = SOC_TS_TOPIC,
+) -> OpenWBIntegration:
+    charging_station = ChargingStation(
+        vin=VIN,
+        charge_state_topic=CHARGE_STATE_TOPIC,
+        charging_value=CHARGING_VALUE,
+        soc_topic=soc_topic,
+        soc_ts_topic=soc_ts_topic,
+    )
+    charging_station.range_topic = RANGE_TOPIC
+    return OpenWBIntegration(
+        charging_station=charging_station,
+        publisher=publisher,
+    )
+
+
 class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         config = Configuration()
         config.anonymized_publishing = False
         self.publisher = MessageCapturingConsolePublisher(config)
-        vin_info = VinInfo()
-        vin_info.vin = VIN
-        vehicle_info = VehicleInfo(vin_info, None)
-        account_prefix = f"/vehicles/{VIN}"
-        scheduler = BlockingScheduler()
-        self.vehicle_state = VehicleState(
-            self.publisher, scheduler, account_prefix, vehicle_info
-        )
-        charging_station = ChargingStation(
-            vin=VIN,
-            charge_state_topic=CHARGE_STATE_TOPIC,
-            charging_value=CHARGING_VALUE,
-            soc_topic=SOC_TOPIC,
-            soc_ts_topic=SOC_TS_TOPIC,
-        )
-        charging_station.range_topic = RANGE_TOPIC
-        self.openwb_integration = OpenWBIntegration(
-            charging_station=charging_station,
-            publisher=self.publisher,
-        )
+        self.vehicle_state = _make_vehicle_state(self.publisher)
+        self.openwb_integration = _make_integration(self.publisher)
 
     @patch("integrations.openwb.datetime")
     async def test_update_soc_with_no_bms_data(self, mock_datetime: Any) -> None:
         mock_datetime.datetime.now.return_value = FROZEN_TIME
-        mock_datetime.timezone = datetime.timezone
+        mock_datetime.UTC = datetime.UTC
         vehicle_status_resp = get_mock_vehicle_status_resp()
         result = self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
 
@@ -88,11 +99,12 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
             RANGE_TOPIC,
         }
         assert expected_topics == set(self.publisher.map.keys())
+        mock_datetime.datetime.now.assert_called_with(tz=datetime.UTC)
 
     @patch("integrations.openwb.datetime")
     async def test_update_soc_with_bms_data(self, mock_datetime: Any) -> None:
         mock_datetime.datetime.now.return_value = FROZEN_TIME
-        mock_datetime.timezone = datetime.timezone
+        mock_datetime.UTC = datetime.UTC
         vehicle_status_resp = get_mock_vehicle_status_resp()
         chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
         vehicle_status_resp_result = self.vehicle_state.handle_vehicle_status(
@@ -122,6 +134,38 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
         expected_topics = {
             SOC_TOPIC,
             SOC_TS_TOPIC,
+            RANGE_TOPIC,
+        }
+        assert expected_topics == set(self.publisher.map.keys())
+        mock_datetime.datetime.now.assert_called_with(tz=datetime.UTC)
+
+    async def test_no_soc_ts_topic_configured(self) -> None:
+        """SoC timestamp is not published when socTsTopic is not configured."""
+        integration = _make_integration(self.publisher, soc_ts_topic=None)
+        vehicle_status_resp = get_mock_vehicle_status_resp()
+        result = self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
+
+        self.publisher.map.clear()
+
+        integration.update_openwb(vehicle_status=result, charge_status=None)
+        expected_topics = {
+            SOC_TOPIC,
+            RANGE_TOPIC,
+        }
+        assert expected_topics == set(self.publisher.map.keys())
+
+    async def test_no_soc_topic_skips_soc_ts(self) -> None:
+        """SoC timestamp is not published when socTopic is not configured, even if socTsTopic is."""
+        integration = _make_integration(
+            self.publisher, soc_topic=None, soc_ts_topic=SOC_TS_TOPIC
+        )
+        vehicle_status_resp = get_mock_vehicle_status_resp()
+        result = self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
+
+        self.publisher.map.clear()
+
+        integration.update_openwb(vehicle_status=result, charge_status=None)
+        expected_topics = {
             RANGE_TOPIC,
         }
         assert expected_topics == set(self.publisher.map.keys())


### PR DESCRIPTION
## Summary
- Adds optional `socTsTopic` configuration to publish a Unix timestamp alongside the SoC value for openWB 2.0 compatibility
- Timestamp is only published when SoC is actually available, avoiding misleading updates when SoC is `None`
- Updates sample config, README docs, and parser to support the new field

Closes #378, supersedes #380

Based on the work by @tosate in #380, rebased onto latest `develop` with the review fix applied (timestamp nested inside SoC guard).

## Test plan
- [x] Existing openWB tests updated and passing
- [x] `ruff check` passes
- [x] `mypy` passes
- [ ] Verify openWB 2.0 receives `soc_timestamp` correctly when SoC is published
- [ ] Verify no timestamp is published when SoC is `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)