### PR TITLE
feat: energy-based vehicle refresh for openWB

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,16 @@ The key-value pairs in the JSON express the following:
 | rangeTopic            | topic where the gateway publishes the range for the charging station - optional                   |
 | chargerConnectedTopic | topic indicating that the vehicle is connected to the charging station - optional                 |
 | chargerConnectedValue | payload that indicates that the charger is connected - optional                                   |
+| importedEnergyTopic   | topic providing the imported energy (Wh) from the charging station - optional                     |
 | vin                   | vehicle identification number to map the charging station information to a vehicle - **required** |
+
+#### `importedEnergyTopic`
+
+This topic provides the amount of energy imported by the charging station, measured in watt-hours.
+
+During the charging process, the system normally calculates the vehicle status refresh interval based on the current charging power and the vehicle's battery capacity. However, this estimation can become inaccurate during PV surplus charging, where the charging power fluctuates significantly.
+
+If the charging station can report the total imported energy (for example, the `daily_imported` topic provided by openWB), this value can be used instead to determine when to refresh the vehicle status. This approach ensures more reliable updates even under variable charging conditions.
 
 ### Advanced settings
 

--- a/examples/charging-stations.json.sample_openWB_2.0
+++ b/examples/charging-stations.json.sample_openWB_2.0
@@ -7,6 +7,7 @@
         "rangeTopic": "openWB/set/mqtt/vehicle/2/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/2/get/plug_state",
         "chargerConnectedValue": "true",
+        "importedEnergyTopic": "openWB/chargepoint/2/get/daily_imported",
         "vin": "vin1"
     },
     {
@@ -17,6 +18,7 @@
         "rangeTopic": "openWB/set/mqtt/vehicle/3/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/3/get/plug_state",
         "chargerConnectedValue": "true",
+        "importedEnergyTopic": "openWB/chargepoint/3/get/daily_imported",
         "vin": "vin2"
     }
 ]

--- a/examples/charging-stations.json.sample_openWB_2.0
+++ b/examples/charging-stations.json.sample_openWB_2.0
@@ -7,7 +7,7 @@
         "rangeTopic": "openWB/set/mqtt/vehicle/2/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/2/get/plug_state",
         "chargerConnectedValue": "true",
-        "importedEnergyTopic": "openWB/chargepoint/2/get/daily_imported",
+        "importedEnergyTopic": "openWB/chargepoint/2/get/imported",
         "vin": "vin1"
     },
     {
@@ -18,7 +18,7 @@
         "rangeTopic": "openWB/set/mqtt/vehicle/3/get/range",
         "chargerConnectedTopic": "openWB/chargepoint/3/get/plug_state",
         "chargerConnectedValue": "true",
-        "importedEnergyTopic": "openWB/chargepoint/3/get/daily_imported",
+        "importedEnergyTopic": "openWB/chargepoint/3/get/imported",
         "vin": "vin2"
     }
 ]

--- a/src/configuration/parser.py
+++ b/src/configuration/parser.py
@@ -570,6 +570,7 @@ def __process_charging_stations_file(config: Configuration, json_file: str) -> N
                     range_topic=item.get("rangeTopic"),
                     connected_topic=item.get("chargerConnectedTopic"),
                     connected_value=item.get("chargerConnectedValue"),
+                    imported_energy_topic=item.get("importedEnergyTopic"),
                 )
                 config.charging_stations_by_vin[vin] = charging_station
     except FileNotFoundError:

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -338,6 +338,32 @@ class VehicleHandler:
         return None
 
 
+    def handle_charging_station_energy_imported(
+        self, imported_energy_wh: float
+    ) -> None:
+        if self.openwb_integration is None:
+            return
+        should_refresh = self.openwb_integration.should_refresh_by_imported_energy(
+            imported_energy_wh=imported_energy_wh,
+            battery_capacity_kwh=self.vin_info.real_battery_capacity,
+            charge_polling_min_percent=self.vehicle_state.charge_polling_min_percent,
+        )
+        if should_refresh:
+            LOG.info(
+                "Imported energy threshold reached for VIN %s, forcing refresh",
+                self.vin_info.vin,
+            )
+            self.vehicle_state.set_refresh_mode(
+                RefreshMode.FORCE,
+                "imported energy threshold reached",
+            )
+
+    def handle_charger_connection_state_changed(self, connected: bool) -> None:
+        if self.openwb_integration is None:
+            return
+        self.openwb_integration.set_charger_connection_state(connected)
+
+
 class VehicleHandlerLocator(ABC):
     @abstractmethod
     def get_vehicle_handler(self, vin: str) -> VehicleHandler | None:

--- a/src/integrations/openwb/__init__.py
+++ b/src/integrations/openwb/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import math
 from typing import TYPE_CHECKING
 
 import extractors
@@ -30,6 +31,9 @@ class OpenWBIntegration:
     ) -> None:
         self.__charging_station = charging_station
         self.__publisher = publisher
+        self.__charger_connected: bool | None = None
+        self.__last_imported_energy_wh: float | None = None
+        self.__next_refresh_energy_wh: float | None = None
 
     def update_openwb(
         self,
@@ -67,3 +71,69 @@ class OpenWBIntegration:
                     value=soc_ts,
                     no_prefix=True,
                 )
+
+    def set_charger_connection_state(self, connected: bool) -> None:
+        if self.__charger_connected == connected:
+            return
+        self.__charger_connected = connected
+        if not connected:
+            self.__last_imported_energy_wh = None
+            self.__next_refresh_energy_wh = None
+
+    def should_refresh_by_imported_energy(
+        self,
+        imported_energy_wh: float,
+        battery_capacity_kwh: float | None,
+        charge_polling_min_percent: float,
+    ) -> bool:
+        """Determine if the vehicle status should be refreshed based on imported energy.
+
+        Triggers a refresh when imported energy since the last refresh exceeds a
+        threshold derived from battery capacity and the minimum polling percentage.
+        If imported energy decreases (e.g. daily counter reset), the threshold is
+        recalculated from the new baseline.
+        """
+        if self.__charger_connected is False:
+            LOG.debug("Charger is disconnected, skipping imported energy check")
+            return False
+
+        if battery_capacity_kwh is None:
+            LOG.warning(
+                "Battery capacity not available, cannot calculate energy threshold"
+            )
+            return False
+
+        energy_per_percent = (battery_capacity_kwh * 1000.0) / 100.0
+        energy_for_min_pct = math.ceil(charge_polling_min_percent * energy_per_percent)
+
+        # Detect counter reset (energy decreased) or first call
+        if (
+            self.__next_refresh_energy_wh is None
+            or self.__last_imported_energy_wh is None
+            or imported_energy_wh < self.__last_imported_energy_wh
+        ):
+            self.__next_refresh_energy_wh = imported_energy_wh + energy_for_min_pct
+            self.__last_imported_energy_wh = imported_energy_wh
+            LOG.debug(
+                "Imported energy threshold initialized to %.0f Wh",
+                self.__next_refresh_energy_wh,
+            )
+            return False
+
+        self.__last_imported_energy_wh = imported_energy_wh
+
+        if imported_energy_wh >= self.__next_refresh_energy_wh:
+            LOG.info(
+                "Imported energy threshold of %.0f Wh reached (current: %.0f Wh), "
+                "triggering vehicle refresh",
+                self.__next_refresh_energy_wh,
+                imported_energy_wh,
+            )
+            self.__next_refresh_energy_wh = imported_energy_wh + energy_for_min_pct
+            LOG.debug(
+                "Next imported energy threshold set to %.0f Wh",
+                self.__next_refresh_energy_wh,
+            )
+            return True
+
+        return False

--- a/src/integrations/openwb/__init__.py
+++ b/src/integrations/openwb/__init__.py
@@ -97,9 +97,17 @@ class OpenWBIntegration:
             LOG.debug("Charger is disconnected, skipping imported energy check")
             return False
 
-        if battery_capacity_kwh is None:
+        if battery_capacity_kwh is None or battery_capacity_kwh <= 0:
             LOG.warning(
-                "Battery capacity not available, cannot calculate energy threshold"
+                "Battery capacity not available or invalid, cannot calculate energy threshold"
+            )
+            return False
+
+        if charge_polling_min_percent <= 0:
+            LOG.warning(
+                "charge_polling_min_percent is %.2f, must be positive; "
+                "skipping energy threshold check",
+                charge_polling_min_percent,
             )
             return False
 

--- a/src/integrations/openwb/charging_station.py
+++ b/src/integrations/openwb/charging_station.py
@@ -15,6 +15,7 @@ class ChargingStation:
         range_topic: str | None = None,
         connected_topic: str | None = None,
         connected_value: str | None = None,
+        imported_energy_topic: str | None = None,
     ) -> None:
         self.vin: Final = vin
         self.charge_state_topic: Final = charge_state_topic
@@ -24,3 +25,4 @@ class ChargingStation:
         self.range_topic: Final = range_topic
         self.connected_topic: Final = connected_topic
         self.connected_value: Final = connected_value
+        self.imported_energy_topic: Final = imported_energy_topic

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -376,6 +376,26 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
             LOG.debug(f"Charging detected for unknown vin {vin}")
 
     @override
+    async def on_charging_station_energy_imported(
+        self, vin: str, imported_energy_wh: float
+    ) -> None:
+        vehicle_handler = self.get_vehicle_handler(vin)
+        if vehicle_handler:
+            vehicle_handler.handle_charging_station_energy_imported(imported_energy_wh)
+        else:
+            LOG.debug(f"Energy imported for unknown vin {vin}")
+
+    @override
+    async def on_charger_connection_state_changed(
+        self, vin: str, connected: bool
+    ) -> None:
+        vehicle_handler = self.get_vehicle_handler(vin)
+        if vehicle_handler:
+            vehicle_handler.handle_charger_connection_state_changed(connected)
+        else:
+            LOG.debug(f"Charger connection state changed for unknown vin {vin}")
+
+    @override
     def on_mqtt_reconnected(self) -> None:
         LOG.info("MQTT reconnected, resetting HA discovery for all vehicles")
         if self.__gateway_discovery is not None:

--- a/src/publisher/core.py
+++ b/src/publisher/core.py
@@ -30,6 +30,18 @@ class MqttCommandListener(ABC):
     ) -> None:
         raise NotImplementedError("Should have implemented this")
 
+    @abstractmethod
+    async def on_charging_station_energy_imported(
+        self, vin: str, imported_energy_wh: float
+    ) -> None:
+        raise NotImplementedError("Should have implemented this")
+
+    @abstractmethod
+    async def on_charger_connection_state_changed(
+        self, vin: str, connected: bool
+    ) -> None:
+        raise NotImplementedError("Should have implemented this")
+
     def on_mqtt_reconnected(self) -> None:  # noqa: B027
         """Reset state when the MQTT client reconnects after a connection loss.
 

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import ssl
 from typing import TYPE_CHECKING, Any, Final, cast, override
 
@@ -183,21 +184,7 @@ class MqttPublisher(Publisher):
                     vin, connected
                 )
         elif topic in self.vin_by_imported_energy_topic:
-            LOG.debug(f"Received message over topic {topic} with payload {payload}")
-            vin = self.vin_by_imported_energy_topic[topic]
-            try:
-                imported_energy_wh = float(payload)
-            except (ValueError, TypeError):
-                LOG.warning(
-                    "Invalid imported energy payload '%s' for topic %s, expected a number",
-                    payload,
-                    topic,
-                )
-                return
-            if self.command_listener is not None:
-                await self.command_listener.on_charging_station_energy_imported(
-                    vin, imported_energy_wh
-                )
+            await self.__handle_imported_energy(topic, payload)
         elif topic == self.configuration.ha_lwt_topic:
             if self.command_listener is not None:
                 await self.command_listener.on_mqtt_global_command_received(
@@ -209,6 +196,30 @@ class MqttPublisher(Publisher):
                 await self.command_listener.on_mqtt_command_received(
                     vin=vin, topic=topic, payload=payload
                 )
+
+    async def __handle_imported_energy(self, topic: str, payload: str) -> None:
+        LOG.debug(f"Received message over topic {topic} with payload {payload}")
+        vin = self.vin_by_imported_energy_topic[topic]
+        try:
+            imported_energy_wh = float(payload)
+        except (ValueError, TypeError):
+            LOG.warning(
+                "Invalid imported energy payload '%s' for topic %s, expected a number",
+                payload,
+                topic,
+            )
+            return
+        if not math.isfinite(imported_energy_wh):
+            LOG.warning(
+                "Non-finite imported energy value '%s' for topic %s, ignoring",
+                payload,
+                topic,
+            )
+            return
+        if self.command_listener is not None:
+            await self.command_listener.on_charging_station_energy_imported(
+                vin, imported_energy_wh
+            )
 
     def __publish(self, topic: str, payload: Any) -> None:
         self.client.publish(topic, payload, retain=True)

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -26,6 +26,7 @@ class MqttPublisher(Publisher):
         self.vin_by_charge_state_topic: dict[str, str] = {}
         self.last_charge_state_by_vin: dict[str, str] = {}
         self.vin_by_charger_connected_topic: dict[str, str] = {}
+        self.vin_by_imported_energy_topic: dict[str, str] = {}
         self.first_connection = True
 
         mqtt_client = gmqtt.Client(
@@ -129,6 +130,14 @@ class MqttPublisher(Publisher):
                     charging_station.connected_topic
                 ] = charging_station.vin
                 self.client.subscribe(charging_station.connected_topic)
+            if charging_station.imported_energy_topic:
+                LOG.debug(
+                    f"Subscribing to MQTT topic {charging_station.imported_energy_topic}"
+                )
+                self.vin_by_imported_energy_topic[
+                    charging_station.imported_energy_topic
+                ] = charging_station.vin
+                self.client.subscribe(charging_station.imported_energy_topic)
         if self.configuration.ha_discovery_enabled:
             # enable dynamic discovery pushing in case ha reconnects
             self.client.subscribe(self.configuration.ha_lwt_topic)
@@ -160,13 +169,34 @@ class MqttPublisher(Publisher):
             LOG.debug(f"Received message over topic {topic} with payload {payload}")
             vin = self.vin_by_charger_connected_topic[topic]
             charging_station = self.configuration.charging_stations_by_vin[vin]
-            if payload == charging_station.connected_value:
+            connected = payload == charging_station.connected_value
+            if connected:
                 LOG.debug(
                     f"Vehicle with vin {vin} is connected to its charging station"
                 )
             else:
                 LOG.debug(
                     f"Vehicle with vin {vin} is disconnected from its charging station"
+                )
+            if self.command_listener is not None:
+                await self.command_listener.on_charger_connection_state_changed(
+                    vin, connected
+                )
+        elif topic in self.vin_by_imported_energy_topic:
+            LOG.debug(f"Received message over topic {topic} with payload {payload}")
+            vin = self.vin_by_imported_energy_topic[topic]
+            try:
+                imported_energy_wh = float(payload)
+            except (ValueError, TypeError):
+                LOG.warning(
+                    "Invalid imported energy payload '%s' for topic %s, expected a number",
+                    payload,
+                    topic,
+                )
+                return
+            if self.command_listener is not None:
+                await self.command_listener.on_charging_station_energy_imported(
+                    vin, imported_energy_wh
                 )
         elif topic == self.configuration.ha_lwt_topic:
             if self.command_listener is not None:

--- a/tests/integrations/openwb/test_openwb_integration.py
+++ b/tests/integrations/openwb/test_openwb_integration.py
@@ -210,6 +210,30 @@ class TestImportedEnergyRefresh(unittest.TestCase):
         )
         assert not result
 
+    def test_zero_battery_capacity_returns_false(self) -> None:
+        result = self.integration.should_refresh_by_imported_energy(
+            imported_energy_wh=1000.0,
+            battery_capacity_kwh=0.0,
+            charge_polling_min_percent=CHARGE_POLLING_MIN_PERCENT,
+        )
+        assert not result
+
+    def test_negative_battery_capacity_returns_false(self) -> None:
+        result = self.integration.should_refresh_by_imported_energy(
+            imported_energy_wh=1000.0,
+            battery_capacity_kwh=-1.0,
+            charge_polling_min_percent=CHARGE_POLLING_MIN_PERCENT,
+        )
+        assert not result
+
+    def test_zero_polling_percent_returns_false(self) -> None:
+        result = self.integration.should_refresh_by_imported_energy(
+            imported_energy_wh=1000.0,
+            battery_capacity_kwh=BATTERY_CAPACITY_KWH,
+            charge_polling_min_percent=0.0,
+        )
+        assert not result
+
     def test_first_call_initializes_threshold(self) -> None:
         assert not self._should_refresh(1000.0)
 
@@ -237,6 +261,11 @@ class TestImportedEnergyRefresh(unittest.TestCase):
         assert not self._should_refresh(0.0)
         # New threshold from 0
         assert self._should_refresh(float(ENERGY_THRESHOLD))
+
+    def test_unknown_charger_state_allows_energy_check(self) -> None:
+        """Energy check proceeds when charger connection state is unknown (no topic configured)."""
+        assert not self._should_refresh(1000.0)  # initializes
+        assert self._should_refresh(1000.0 + ENERGY_THRESHOLD)  # triggers
 
     def test_charger_disconnected_skips_check(self) -> None:
         self.integration.set_charger_connection_state(False)

--- a/tests/integrations/openwb/test_openwb_integration.py
+++ b/tests/integrations/openwb/test_openwb_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import math
 from typing import Any
 import unittest
 from unittest.mock import patch
@@ -31,6 +32,12 @@ SOC_TS_TOPIC = "/mock/soc/timestamp"
 CHARGING_VALUE = "VehicleIsCharging"
 
 FROZEN_TIME = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+
+# Constants for imported energy tests
+BATTERY_CAPACITY_KWH = 64.0
+CHARGE_POLLING_MIN_PERCENT = 1.0
+ENERGY_PER_PERCENT = BATTERY_CAPACITY_KWH * 1000.0 / 100.0
+ENERGY_THRESHOLD = math.ceil(CHARGE_POLLING_MIN_PERCENT * ENERGY_PER_PERCENT)
 
 
 def _make_vehicle_state(publisher: MessageCapturingConsolePublisher) -> VehicleState:
@@ -179,3 +186,67 @@ class TestOpenWBIntegration(unittest.IsolatedAsyncioTestCase):
                 assert value == mqtt_map[topic]
         else:
             self.fail(f"MQTT map does not contain topic {topic}")
+
+
+class TestImportedEnergyRefresh(unittest.TestCase):
+    def setUp(self) -> None:
+        config = Configuration()
+        config.anonymized_publishing = False
+        publisher = MessageCapturingConsolePublisher(config)
+        self.integration = _make_integration(publisher)
+
+    def _should_refresh(self, energy_wh: float) -> bool:
+        return self.integration.should_refresh_by_imported_energy(
+            imported_energy_wh=energy_wh,
+            battery_capacity_kwh=BATTERY_CAPACITY_KWH,
+            charge_polling_min_percent=CHARGE_POLLING_MIN_PERCENT,
+        )
+
+    def test_no_battery_capacity_returns_false(self) -> None:
+        result = self.integration.should_refresh_by_imported_energy(
+            imported_energy_wh=1000.0,
+            battery_capacity_kwh=None,
+            charge_polling_min_percent=CHARGE_POLLING_MIN_PERCENT,
+        )
+        assert not result
+
+    def test_first_call_initializes_threshold(self) -> None:
+        assert not self._should_refresh(1000.0)
+
+    def test_below_threshold_no_refresh(self) -> None:
+        self._should_refresh(1000.0)  # initialize
+        assert not self._should_refresh(1000.0 + ENERGY_THRESHOLD - 1)
+
+    def test_at_threshold_triggers_refresh(self) -> None:
+        self._should_refresh(1000.0)  # initialize
+        assert self._should_refresh(1000.0 + ENERGY_THRESHOLD)
+
+    def test_next_threshold_after_refresh(self) -> None:
+        self._should_refresh(1000.0)  # initialize
+        energy_at_first_refresh = 1000.0 + ENERGY_THRESHOLD
+        assert self._should_refresh(energy_at_first_refresh)
+        # Should not refresh again immediately
+        assert not self._should_refresh(energy_at_first_refresh + 1)
+        # Should refresh at second threshold
+        assert self._should_refresh(energy_at_first_refresh + ENERGY_THRESHOLD)
+
+    def test_counter_reset_reinitializes(self) -> None:
+        self._should_refresh(5000.0)  # initialize at 5kWh
+        assert self._should_refresh(5000.0 + ENERGY_THRESHOLD)  # first refresh
+        # Counter resets to 0 (e.g. daily reset)
+        assert not self._should_refresh(0.0)
+        # New threshold from 0
+        assert self._should_refresh(float(ENERGY_THRESHOLD))
+
+    def test_charger_disconnected_skips_check(self) -> None:
+        self.integration.set_charger_connection_state(False)
+        assert not self._should_refresh(99999.0)
+
+    def test_charger_reconnect_resets_state(self) -> None:
+        self._should_refresh(1000.0)  # initialize
+        self.integration.set_charger_connection_state(False)
+        self.integration.set_charger_connection_state(True)
+        # After reconnect, first call re-initializes (returns False)
+        assert not self._should_refresh(0.0)
+        # Then threshold works from new baseline
+        assert self._should_refresh(float(ENERGY_THRESHOLD))

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -86,3 +86,13 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
 
     async def on_charging_detected(self, vin: str) -> None:
         pass
+
+    async def on_charging_station_energy_imported(
+        self, vin: str, imported_energy_wh: float
+    ) -> None:
+        pass
+
+    async def on_charger_connection_state_changed(
+        self, vin: str, connected: bool
+    ) -> None:
+        pass


### PR DESCRIPTION
## Summary
- Adds optional `importedEnergyTopic` to monitor energy imported by the charging station (Wh) and trigger vehicle status refreshes based on actual energy consumed
- Improves refresh accuracy during PV surplus charging where power fluctuates and time-based estimates are unreliable
- Tracks charger connection state to reset energy thresholds on disconnect/reconnect
- Validates incoming MQTT payloads with try/except to prevent crashes on non-numeric data

Closes #387, supersedes #392

Based on the work by @tosate in #392, rebased onto latest `develop` with review fixes applied:
- Fixed copy-paste bug in sample config (vin2 was using chargepoint 2 topics)
- Added `float(payload)` validation with warning log
- Used explicit `is None` checks instead of truthiness checks
- Used UTC-aware datetimes

## Test plan
- [x] 8 unit tests for imported energy refresh logic (threshold init, trigger, reset, disconnect, reconnect)
- [x] Existing openWB tests pass
- [x] `ruff check` passes
- [x] `mypy` passes
- [ ] Verify with openWB `daily_imported` topic during PV surplus charging

🤖 Generated with [Claude Code](https://claude.com/claude-code)