### PR TITLE
fix: reject vehicle status updates with bogus timestamps

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -7,3 +7,7 @@ class MqttGatewayException(Exception):
 
     def __str__(self) -> str:
         return self.message
+
+
+class VehicleStatusDriftException(MqttGatewayException):
+    """Raised when the vehicle status timestamp has drifted too far from the current time."""

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from saic_ismart_client_ng.exceptions import SaicApiException, SaicLogoutException
 
+from exceptions import VehicleStatusDriftException
 from handlers.vehicle_command import VehicleCommandHandler
 from integrations import IntegrationException
 from integrations.abrp.api import AbrpApi
@@ -169,6 +170,12 @@ class VehicleHandler:
                     self.vehicle_state.mark_failed_refresh()
                     LOG.exception(
                         "handle_vehicle loop failed during SAIC API call", exc_info=e
+                    )
+                except VehicleStatusDriftException as e:
+                    self.vehicle_state.mark_failed_refresh()
+                    LOG.error(
+                        "Skipping vehicle status update: %s",
+                        e,
                     )
                 except IntegrationException as ae:
                     LOG.exception(

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Final, override
 
 from saic_ismart_client_ng.api.vehicle import VehicleStatusResp
 
-from exceptions import MqttGatewayException
+from exceptions import MqttGatewayException, VehicleStatusDriftException
 import mqtt_topics
 from status_publisher import VehicleDataPublisher
 from status_publisher.vehicle.basic_vehicle_status import (
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 
     from publisher.core import Publisher
     from vehicle_info import VehicleInfo
+
+
+_INVALID_TIMESTAMPS: Final = frozenset({0, 2147483647})
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -54,15 +57,20 @@ class VehicleStatusRespPublisher(
     def publish(
         self, vehicle_status: VehicleStatusResp
     ) -> VehicleStatusRespProcessingResult:
+        status_time = vehicle_status.statusTime
+        if status_time is None or status_time in _INVALID_TIMESTAMPS:
+            msg = f"Vehicle status has invalid timestamp: {status_time}"
+            raise VehicleStatusDriftException(msg)
+
         vehicle_status_time = datetime.datetime.fromtimestamp(
-            vehicle_status.statusTime or 0, tz=datetime.UTC
+            status_time, tz=datetime.UTC
         )
         now_time = datetime.datetime.now(tz=datetime.UTC)
         vehicle_status_drift = abs(now_time - vehicle_status_time)
 
         if vehicle_status_drift > datetime.timedelta(minutes=15):
             msg = f"Vehicle status time drifted more than 15 minutes from current time: {vehicle_status_drift}. Server reported {vehicle_status_time}"
-            raise MqttGatewayException(msg)
+            raise VehicleStatusDriftException(msg)
 
         basic_vehicle_status = vehicle_status.basicVehicleStatus
         if basic_vehicle_status:

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -18,6 +18,7 @@ from saic_ismart_client_ng.api.vehicle_charging.schema import (
 )
 
 from configuration import Configuration
+from exceptions import VehicleStatusDriftException
 import mqtt_topics
 from vehicle import RefreshMode, VehicleState
 from vehicle_info import VehicleInfo
@@ -255,6 +256,30 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         result = json.loads(self.publisher.map[topic])
         assert result["startTime"] == "08:00"
         assert result["mode"] == "on"
+
+    def test_handle_vehicle_status_rejects_none_timestamp(self) -> None:
+        resp = get_mock_vehicle_status_resp()
+        resp.statusTime = None
+        with pytest.raises(VehicleStatusDriftException, match="invalid timestamp"):
+            self.vehicle_state.handle_vehicle_status(resp)
+
+    def test_handle_vehicle_status_rejects_zero_timestamp(self) -> None:
+        resp = get_mock_vehicle_status_resp()
+        resp.statusTime = 0
+        with pytest.raises(VehicleStatusDriftException, match="invalid timestamp"):
+            self.vehicle_state.handle_vehicle_status(resp)
+
+    def test_handle_vehicle_status_rejects_max_int32_timestamp(self) -> None:
+        resp = get_mock_vehicle_status_resp()
+        resp.statusTime = 2147483647
+        with pytest.raises(VehicleStatusDriftException, match="invalid timestamp"):
+            self.vehicle_state.handle_vehicle_status(resp)
+
+    def test_handle_vehicle_status_rejects_drifted_timestamp(self) -> None:
+        resp = get_mock_vehicle_status_resp()
+        resp.statusTime = 1000000000  # 2001-09-09, well outside 15 min window
+        with pytest.raises(VehicleStatusDriftException, match="drifted more than 15 minutes"):
+            self.vehicle_state.handle_vehicle_status(resp)
 
     @staticmethod
     def get_topic(sub_topic: str) -> str:


### PR DESCRIPTION
## Summary

- Adds `VehicleStatusDriftException` to distinguish timestamp issues from unexpected errors
- Rejects vehicle status updates with invalid timestamps (`None`, `0`, `2147483647`/Y2K38 sentinel) upfront
- Catches `VehicleStatusDriftException` in the vehicle handler loop and logs a clean error message instead of "handle_vehicle loop failed with an unexpected exception" with a full stack trace
- Adds 4 test cases covering all rejection scenarios

## Supersedes #393

PR #393 took the approach of silently skipping the drift check for bogus timestamps and processing the data anyway. This PR takes the opposite approach: if the timestamp is bogus, the entire payload is unreliable and should be rejected. The key differences:

- #393: detects `2147483647` but still processes the vehicle status → risks publishing stale/garbage data
- This PR: detects the same sentinel values but **rejects the entire update**, keeping the existing drift-check semantics intact while improving error reporting

## Closes

- Closes #410
- Closes #391 (and its duplicate #263)

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes
- [x] All 126 tests pass, including 4 new test cases:
  - `test_handle_vehicle_status_rejects_none_timestamp`
  - `test_handle_vehicle_status_rejects_zero_timestamp`
  - `test_handle_vehicle_status_rejects_max_int32_timestamp`
  - `test_handle_vehicle_status_rejects_drifted_timestamp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)