### PR TITLE
fix: skip partial mileage values that exceed total mileage

### DIFF
--- a/src/status_publisher/charge/chrg_mgmt_data_resp.py
+++ b/src/status_publisher/charge/chrg_mgmt_data_resp.py
@@ -57,6 +57,9 @@ class ChrgMgmtDataRespPublisher(
             vin, publisher, mqtt_vehicle_prefix
         )
 
+    def update_total_mileage(self, raw_mileage: int) -> None:
+        self.__rvs_charge_status_publisher.update_total_mileage(raw_mileage)
+
     def publish(
         self, chrg_mgmt_data_resp: ChrgMgmtDataResp
     ) -> ChrgMgmtDataRespProcessingResult:

--- a/src/status_publisher/charge/rvs_charge_status.py
+++ b/src/status_publisher/charge/rvs_charge_status.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from saic_ismart_client_ng.api.vehicle_charging import RvsChargeStatus
 
 import mqtt_topics
 from status_publisher import VehicleDataPublisher
 from utils import int_to_bool, value_in_range
+
+if TYPE_CHECKING:
+    from publisher.core import Publisher
+    from vehicle_info import VehicleInfo
 
 LOG = logging.getLogger(__name__)
 
@@ -22,6 +26,27 @@ class RvsChargeStatusProcessingResult:
 class RvsChargeStatusPublisher(
     VehicleDataPublisher[RvsChargeStatus, RvsChargeStatusProcessingResult]
 ):
+    def __init__(
+        self, vin: VehicleInfo, publisher: Publisher, mqtt_vehicle_prefix: str
+    ) -> None:
+        super().__init__(vin, publisher, mqtt_vehicle_prefix)
+        self._last_total_mileage_raw: int | None = None
+
+    def update_total_mileage(self, raw_mileage: int) -> None:
+        self._last_total_mileage_raw = raw_mileage
+
+    def _is_valid_partial_mileage(self, raw_value: int) -> bool:
+        if not value_in_range(raw_value, 0, 65535):
+            return False
+        if self._last_total_mileage_raw is not None and raw_value > self._last_total_mileage_raw:
+            LOG.warning(
+                "Partial mileage %d exceeds total mileage %d, skipping",
+                raw_value,
+                self._last_total_mileage_raw,
+            )
+            return False
+        return True
+
     @override
     def publish(
         self, charge_status: RvsChargeStatus
@@ -29,14 +54,14 @@ class RvsChargeStatusPublisher(
         self._transform_and_publish(
             topic=mqtt_topics.DRIVETRAIN_MILEAGE_OF_DAY,
             value=charge_status.mileageOfDay,
-            validator=lambda x: value_in_range(x, 0, 65535),
+            validator=self._is_valid_partial_mileage,
             transform=lambda x: x / 10.0,
         )
 
         self._transform_and_publish(
             topic=mqtt_topics.DRIVETRAIN_MILEAGE_SINCE_LAST_CHARGE,
             value=charge_status.mileageSinceLastCharge,
-            validator=lambda x: value_in_range(x, 0, 65535),
+            validator=self._is_valid_partial_mileage,
             transform=lambda x: x / 10.0,
         )
 

--- a/src/status_publisher/vehicle/basic_vehicle_status.py
+++ b/src/status_publisher/vehicle/basic_vehicle_status.py
@@ -21,6 +21,7 @@ class BasicVehicleStatusProcessingResult:
     is_parked: bool
     fuel_rage_elec: int | None
     raw_soc: int | None
+    raw_mileage: int | None
 
 
 class BasicVehicleStatusPublisher(
@@ -236,6 +237,7 @@ class BasicVehicleStatusPublisher(
             remote_heated_seats_front_right_level=front_right_seat_level,
             fuel_rage_elec=basic_vehicle_status.fuelRangeElec,
             raw_soc=basic_vehicle_status.extendedData1,
+            raw_mileage=basic_vehicle_status.mileage if is_valid_mileage else None,
         )
 
     def __publish_tyre(self, raw_value: int | None, topic: str) -> None:

--- a/src/status_publisher/vehicle/vehicle_status_resp.py
+++ b/src/status_publisher/vehicle/vehicle_status_resp.py
@@ -37,6 +37,7 @@ class VehicleStatusRespProcessingResult:
     remote_heated_seats_front_left_level: int | None
     fuel_range_elec: int | None
     raw_soc: int | None
+    raw_mileage: int | None
 
 
 class VehicleStatusRespPublisher(
@@ -102,6 +103,7 @@ class VehicleStatusRespPublisher(
             remote_heated_seats_front_right_level=basic_vehicle_status_result.remote_heated_seats_front_right_level,
             raw_soc=basic_vehicle_status_result.raw_soc,
             fuel_range_elec=basic_vehicle_status_result.fuel_rage_elec,
+            raw_mileage=basic_vehicle_status_result.raw_mileage,
         )
 
     def __on_gps_position(

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -282,6 +282,10 @@ class VehicleState:
             self.__remote_heated_seats_front_right_level = (
                 processing_result.remote_heated_seats_front_right_level
             )
+        if processing_result.raw_mileage is not None:
+            self.__charge_response_publisher.update_total_mileage(
+                processing_result.raw_mileage
+            )
         return processing_result
 
     @property

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -24,6 +24,8 @@ from vehicle import RefreshMode, VehicleState
 from vehicle_info import VehicleInfo
 
 from .common_mocks import (
+    DRIVETRAIN_MILEAGE,
+    DRIVETRAIN_MILEAGE_OF_DAY,
     DRIVETRAIN_RANGE_BMS,
     DRIVETRAIN_RANGE_VEHICLE,
     DRIVETRAIN_SOC_BMS,
@@ -280,6 +282,59 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         resp.statusTime = 1000000000  # 2001-09-09, well outside 15 min window
         with pytest.raises(VehicleStatusDriftException, match="drifted more than 15 minutes"):
             self.vehicle_state.handle_vehicle_status(resp)
+
+    def test_mileage_of_day_published_when_valid(self) -> None:
+        """Mileage of day is published when it does not exceed total mileage."""
+        vehicle_status_resp = get_mock_vehicle_status_resp()
+        self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
+        chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
+        self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
+
+        self.assert_mqtt_topic(
+            self.get_topic(mqtt_topics.DRIVETRAIN_MILEAGE_OF_DAY),
+            DRIVETRAIN_MILEAGE_OF_DAY,
+        )
+
+    def test_mileage_of_day_skipped_when_exceeds_total(self) -> None:
+        """Mileage of day should not be published when it exceeds total mileage."""
+        vehicle_status_resp = get_mock_vehicle_status_resp()
+        self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
+
+        chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
+        # Set mileageOfDay raw value higher than total mileage raw value
+        assert chrg_mgmt_data_resp.rvsChargeStatus is not None
+        chrg_mgmt_data_resp.rvsChargeStatus.mileageOfDay = (DRIVETRAIN_MILEAGE + 100) * 10
+        self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
+
+        assert (
+            self.get_topic(mqtt_topics.DRIVETRAIN_MILEAGE_OF_DAY)
+            not in self.publisher.map
+        )
+
+    def test_mileage_since_last_charge_skipped_when_exceeds_total(self) -> None:
+        """Mileage since last charge should not be published when it exceeds total mileage."""
+        vehicle_status_resp = get_mock_vehicle_status_resp()
+        self.vehicle_state.handle_vehicle_status(vehicle_status_resp)
+
+        chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
+        assert chrg_mgmt_data_resp.rvsChargeStatus is not None
+        chrg_mgmt_data_resp.rvsChargeStatus.mileageSinceLastCharge = (DRIVETRAIN_MILEAGE + 100) * 10
+        self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
+
+        assert (
+            self.get_topic(mqtt_topics.DRIVETRAIN_MILEAGE_SINCE_LAST_CHARGE)
+            not in self.publisher.map
+        )
+
+    def test_mileage_of_day_published_when_no_vehicle_status_yet(self) -> None:
+        """When vehicle status has never been fetched, partial mileage should still be published."""
+        chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
+        self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
+
+        self.assert_mqtt_topic(
+            self.get_topic(mqtt_topics.DRIVETRAIN_MILEAGE_OF_DAY),
+            DRIVETRAIN_MILEAGE_OF_DAY,
+        )
 
     @staticmethod
     def get_topic(sub_topic: str) -> str:


### PR DESCRIPTION
## Summary

- Do not publish `mileageOfDay` or `mileageSinceLastCharge` when they exceed total vehicle mileage, which indicates garbage data from the SAIC API
- The last known total mileage from vehicle status is stored and used as an upper bound when validating partial mileage fields in charge status
- Invalid mileage values (e.g. `0` or sentinel values that fail the existing mileage validator) are excluded from being used as the comparison ceiling

## Closes

- Closes #286

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes
- [x] All 125 tests pass, including 3 new test cases:
  - `test_mileage_of_day_published_when_valid`
  - `test_mileage_of_day_skipped_when_exceeds_total`
  - `test_mileage_since_last_charge_skipped_when_exceeds_total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)