### PR TITLE
docs: add local setup guide and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+## Development Setup
+
+### Prerequisites
+
+* Python 3.12 or later
+* [Poetry](https://python-poetry.org/docs/#installation) 2.0 or later
+
+### Install Dependencies
+
+```bash
+# Install all dependencies including dev tools (ruff, mypy, pytest, etc.)
+$ poetry install --no-root
+```
+
+### Activate the Virtual Environment
+
+Either activate the environment:
+
+```bash
+$ poetry env activate
+```
+
+Or prefix commands with `poetry run` (shown in the examples below).
+
+## Project Structure
+
+```
+src/            # Application source code
+  main.py       # Entry point
+tests/          # Test suite
+examples/       # Sample configuration files
+```
+
+## Running the Gateway Locally
+
+```bash
+$ poetry run python src/main.py -u <saic-user> -p <saic-pwd> -m tcp://localhost:1883
+```
+
+You can also create a `.env` file in the project root with your configuration:
+
+```
+SAIC_USER=your-user
+SAIC_PASSWORD=your-password
+MQTT_URI=tcp://localhost:1883
+```
+
+Then simply run:
+
+```bash
+$ poetry run python src/main.py
+```
+
+## Code Quality
+
+The CI pipeline runs the following checks on every push and pull request. Run them locally before submitting a PR:
+
+```bash
+# Type checking
+$ poetry run mypy
+
+# Linting
+$ poetry run ruff check .
+
+# Tests with coverage
+$ poetry run pytest tests --cov
+```
+
+## Pull Requests
+
+* PRs should target the `develop` branch
+* Ensure all CI checks pass (mypy, ruff, pytest)

--- a/README.md
+++ b/README.md
@@ -150,12 +150,25 @@ If the charging station can report the total imported energy (for example, the `
 
 ### From Command-line
 
-To run the service from the command line you need to have Python version 3.12 or later.
-Launch the MQTT gateway with the mandatory parametersn and, optionally, the url to the MQTT broker.
+You need Python 3.12 or later and [Poetry](https://python-poetry.org/docs/#installation) 2.0 or later.
 
+These steps mirror what the [Dockerfile](Dockerfile) does:
+
+```bash
+# 1. Install dependencies (production only, no dev tools)
+$ poetry install --no-root --without dev
+
+# 2. Run the gateway
+$ poetry run python src/main.py -u <saic-user> -p <saic-pwd>
 ```
-$ python ./mqtt_gateway.py -m tcp://my-broker-host:1883 -u <saic-user> -p <saic-pwd>
-```
+
+You can optionally specify an MQTT broker with `-m tcp://my-broker-host:1883`.
+
+You can also use a `.env` file in the current working directory to provide configuration
+via environment variables instead of command-line parameters. See the [Configuration](#configuration)
+section for available environment variables.
+
+For development setup, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### In a docker container
 


### PR DESCRIPTION
## Summary
- Updated the README "From Command-line" section with correct prerequisites (Python 3.12+, Poetry 2.0+) and steps that mirror the Dockerfile
- Added a CONTRIBUTING.md with development setup, project structure, code quality commands, and PR guidelines

Closes #356

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Follow the documented steps on a clean checkout to confirm they work

🤖 Generated with [Claude Code](https://claude.com/claude-code)