### PR TITLE
feat: add HA Event entity for vehicle messages

### DIFF
--- a/src/handlers/message.py
+++ b/src/handlers/message.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from saic_ismart_client_ng.exceptions import SaicApiException, SaicLogoutException
 
+from utils import ensure_datetime_aware
 from vehicle import RefreshMode
 
 if TYPE_CHECKING:
@@ -16,13 +17,6 @@ if TYPE_CHECKING:
     from handlers.vehicle import VehicleHandlerLocator
 
 LOG = logging.getLogger(__name__)
-
-
-def _ensure_aware(dt: datetime.datetime) -> datetime.datetime:
-    """Return *dt* with UTC tzinfo if it is naive, otherwise unchanged."""
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=datetime.UTC)
-    return dt
 
 
 class MessageHandler:
@@ -60,10 +54,10 @@ class MessageHandler:
             if (
                 latest_message is not None
                 and latest_message.messageId != self.last_message_id
-                and _ensure_aware(latest_message.message_time) > self.last_message_ts
+                and ensure_datetime_aware(latest_message.message_time) > self.last_message_ts
             ):
                 self.last_message_id = latest_message.messageId
-                self.last_message_ts = _ensure_aware(latest_message.message_time)
+                self.last_message_ts = ensure_datetime_aware(latest_message.message_time)
                 LOG.info(
                     f"{latest_message.title} detected at {latest_message.message_time}"
                 )
@@ -113,7 +107,7 @@ class MessageHandler:
                 oldest_message = self.__get_oldest_message(all_messages)
                 if (
                     oldest_message is not None
-                    and _ensure_aware(oldest_message.message_time) < self.last_message_ts
+                    and ensure_datetime_aware(oldest_message.message_time) < self.last_message_ts
                 ):
                     return all_messages
             except SaicLogoutException:
@@ -180,7 +174,7 @@ class MessageHandler:
     ) -> MessageEntity | None:
         if len(vehicle_start_messages) == 0:
             return None
-        return max(vehicle_start_messages, key=lambda m: m.message_time)
+        return max(vehicle_start_messages, key=lambda m: ensure_datetime_aware(m.message_time))
 
     @staticmethod
     def __get_oldest_message(
@@ -188,4 +182,4 @@ class MessageHandler:
     ) -> MessageEntity | None:
         if len(vehicle_start_messages) == 0:
             return None
-        return min(vehicle_start_messages, key=lambda m: m.message_time)
+        return min(vehicle_start_messages, key=lambda m: ensure_datetime_aware(m.message_time))

--- a/src/handlers/message.py
+++ b/src/handlers/message.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
+def _ensure_aware(dt: datetime.datetime) -> datetime.datetime:
+    """Return *dt* with UTC tzinfo if it is naive, otherwise unchanged."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.UTC)
+    return dt
+
+
 class MessageHandler:
     def __init__(
         self,
@@ -53,10 +60,10 @@ class MessageHandler:
             if (
                 latest_message is not None
                 and latest_message.messageId != self.last_message_id
-                and latest_message.message_time > self.last_message_ts
+                and _ensure_aware(latest_message.message_time) > self.last_message_ts
             ):
                 self.last_message_id = latest_message.messageId
-                self.last_message_ts = latest_message.message_time
+                self.last_message_ts = _ensure_aware(latest_message.message_time)
                 LOG.info(
                     f"{latest_message.title} detected at {latest_message.message_time}"
                 )
@@ -106,7 +113,7 @@ class MessageHandler:
                 oldest_message = self.__get_oldest_message(all_messages)
                 if (
                     oldest_message is not None
-                    and oldest_message.message_time < self.last_message_ts
+                    and _ensure_aware(oldest_message.message_time) < self.last_message_ts
                 ):
                     return all_messages
             except SaicLogoutException:

--- a/src/handlers/vehicle_command.py
+++ b/src/handlers/vehicle_command.py
@@ -86,10 +86,9 @@ class VehicleCommandHandler:
             }
             self.publisher.publish_json(error_topic, event_payload, retain=False)
         except Exception:
-            LOG.warning(
+            LOG.exception(
                 "Failed to publish command error event for command %s",
                 command,
-                exc_info=True,
             )
 
     async def handle_mqtt_command(self, *, topic: str, payload: str) -> None:

--- a/src/handlers/vehicle_command.py
+++ b/src/handlers/vehicle_command.py
@@ -84,7 +84,7 @@ class VehicleCommandHandler:
                 "command": command,
                 "detail": detail,
             }
-            self.publisher.publish_json(error_topic, event_payload)
+            self.publisher.publish_json(error_topic, event_payload, retain=False)
         except Exception:
             LOG.warning(
                 "Failed to publish command error event for command %s",

--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -327,13 +327,19 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
         )
         self.__publish_lights_sensors()
 
-        # Command error event
+        # Event entities
         self._publish_event(
             mqtt_topics.COMMAND_ERROR,
             "Command error",
             ["command_error"],
             entity_category="diagnostic",
             icon="mdi:alert-circle",
+        )
+        self._publish_event(
+            mqtt_topics.EVENTS_VEHICLE_MESSAGE,
+            "Vehicle message",
+            ["vehicle_message"],
+            icon="mdi:message-text",
         )
 
         LOG.debug("Completed publishing Home Assistant discovery messages")

--- a/src/mqtt_topics.py
+++ b/src/mqtt_topics.py
@@ -182,4 +182,7 @@ TYRES_REAR_RIGHT_PRESSURE = TYRES + "/rearRightPressure"
 COMMAND = "command"
 COMMAND_ERROR = COMMAND + "/error"
 
+EVENTS = "events"
+EVENTS_VEHICLE_MESSAGE = EVENTS + "/vehicleMessage"
+
 VEHICLES = "vehicles"

--- a/src/publisher/core.py
+++ b/src/publisher/core.py
@@ -75,7 +75,12 @@ class Publisher(ABC):
 
     @abstractmethod
     def publish_json(
-        self, key: str, data: dict[str, Any], no_prefix: bool = False
+        self,
+        key: str,
+        data: dict[str, Any],
+        no_prefix: bool = False,
+        *,
+        retain: bool = True,
     ) -> None:
         raise NotImplementedError
 

--- a/src/publisher/log_publisher.py
+++ b/src/publisher/log_publisher.py
@@ -24,7 +24,12 @@ class ConsolePublisher(Publisher):
 
     @override
     def publish_json(
-        self, key: str, data: dict[str, Any], no_prefix: bool = False
+        self,
+        key: str,
+        data: dict[str, Any],
+        no_prefix: bool = False,
+        *,
+        retain: bool = True,
     ) -> None:
         anonymized_json = self.dict_to_anonymized_json(data)
         self.internal_publish(key, anonymized_json)

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -221,8 +221,8 @@ class MqttPublisher(Publisher):
                 vin, imported_energy_wh
             )
 
-    def __publish(self, topic: str, payload: Any) -> None:
-        self.client.publish(topic, payload, retain=True)
+    def __publish(self, topic: str, payload: Any, *, retain: bool = True) -> None:
+        self.client.publish(topic, payload, retain=retain)
 
     @override
     def is_connected(self) -> bool:
@@ -230,10 +230,17 @@ class MqttPublisher(Publisher):
 
     @override
     def publish_json(
-        self, key: str, data: dict[str, Any], no_prefix: bool = False
+        self,
+        key: str,
+        data: dict[str, Any],
+        no_prefix: bool = False,
+        *,
+        retain: bool = True,
     ) -> None:
         payload = self.dict_to_anonymized_json(data)
-        self.__publish(topic=self.get_topic(key, no_prefix), payload=payload)
+        self.__publish(
+            topic=self.get_topic(key, no_prefix), payload=payload, retain=retain
+        )
 
     @override
     def publish_str(self, key: str, value: str, no_prefix: bool = False) -> None:

--- a/src/status_publisher/__init__.py
+++ b/src/status_publisher/__init__.py
@@ -35,11 +35,14 @@ class VehicleDataPublisher[I, O](metaclass=ABCMeta):
         value: Publishable | None,
         validator: Callable[[Publishable], bool] = lambda _: True,
         no_prefix: bool = False,
+        retain: bool = True,
     ) -> tuple[bool, Publishable | None]:
         if value is None or not validator(value):
             return False, None
         actual_topic = topic if no_prefix else self.__get_topic(topic)
-        published = self._publish_directly(topic=actual_topic, value=value)
+        published = self._publish_directly(
+            topic=actual_topic, value=value, retain=retain
+        )
         return published, value
 
     def _transform_and_publish(
@@ -58,7 +61,9 @@ class VehicleDataPublisher[I, O](metaclass=ABCMeta):
         published = self._publish_directly(topic=actual_topic, value=transformed_value)
         return published, transformed_value
 
-    def _publish_directly(self, *, topic: str, value: Publishable) -> bool:
+    def _publish_directly(
+        self, *, topic: str, value: Publishable, retain: bool = True
+    ) -> bool:
         published = False
         if isinstance(value, bool):
             self.__publisher.publish_bool(topic, value)
@@ -73,7 +78,7 @@ class VehicleDataPublisher[I, O](metaclass=ABCMeta):
             self.__publisher.publish_str(topic, value)
             published = True
         elif isinstance(value, dict):
-            self.__publisher.publish_json(topic, value)
+            self.__publisher.publish_json(topic, value, retain=retain)
             published = True
         elif isinstance(value, datetime):
             self.__publisher.publish_str(topic, datetime_to_str(value))

--- a/src/status_publisher/__init__.py
+++ b/src/status_publisher/__init__.py
@@ -53,12 +53,15 @@ class VehicleDataPublisher[I, O](metaclass=ABCMeta):
         validator: Callable[[T], bool] = lambda _: True,
         transform: Callable[[T], Publishable],
         no_prefix: bool = False,
+        retain: bool = True,
     ) -> tuple[bool, Publishable | None]:
         if value is None or not validator(value):
             return False, None
         actual_topic = topic if no_prefix else self.__get_topic(topic)
         transformed_value = transform(value)
-        published = self._publish_directly(topic=actual_topic, value=transformed_value)
+        published = self._publish_directly(
+            topic=actual_topic, value=transformed_value, retain=retain
+        )
         return published, transformed_value
 
     def _publish_directly(

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -15,6 +15,14 @@ if TYPE_CHECKING:
     from vehicle_info import VehicleInfo
 
 LOG = logging.getLogger(__name__)
+_EPOCH_MIN = datetime.min.replace(tzinfo=UTC)
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    """Return *dt* with UTC tzinfo if it is naive, otherwise unchanged."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -29,15 +37,16 @@ class MessagePublisher(
         self, vin: VehicleInfo, publisher: Publisher, mqtt_vehicle_prefix: str
     ) -> None:
         super().__init__(vin, publisher, mqtt_vehicle_prefix)
-        self.__last_car_vehicle_message = datetime.min.replace(tzinfo=UTC)
+        self.__last_car_vehicle_message = _EPOCH_MIN
 
     @override
     def publish(self, message: MessageEntity) -> MessagePublisherProcessingResult:
+        msg_time = _ensure_aware(message.message_time)
         if (
-            self.__last_car_vehicle_message == datetime.min.replace(tzinfo=UTC)
-            or message.message_time > self.__last_car_vehicle_message
+            self.__last_car_vehicle_message == _EPOCH_MIN
+            or msg_time > self.__last_car_vehicle_message
         ):
-            self.__last_car_vehicle_message = message.message_time
+            self.__last_car_vehicle_message = msg_time
             self._publish(
                 topic=mqtt_topics.INFO_LAST_MESSAGE_TIME,
                 value=self.__last_car_vehicle_message,

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -104,6 +104,7 @@ class MessagePublisher(
                     "sender": message.sender or "",
                     "vin": message.vin or "",
                 },
+                retain=False,
             )
         except Exception:
             LOG.exception(

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -91,6 +91,8 @@ class MessagePublisher(
         return MessagePublisherProcessingResult(processed=False)
 
     def __publish_message_event(self, message: MessageEntity) -> None:
+        # Best-effort: a failure here must not prevent the individual
+        # topic publishes above from being reported as successful.
         try:
             self._publish(
                 topic=mqtt_topics.EVENTS_VEHICLE_MESSAGE,
@@ -104,7 +106,8 @@ class MessagePublisher(
                 },
             )
         except Exception:
-            LOG.warning(
-                "Failed to publish vehicle message event",
-                exc_info=True,
+            LOG.exception(
+                "Failed to publish vehicle message event for message %s (VIN: %s)",
+                message.messageId,
+                message.vin,
             )

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+import logging
 from typing import TYPE_CHECKING, override
 
 from saic_ismart_client_ng.api.message import MessageEntity
@@ -12,6 +13,8 @@ from status_publisher import VehicleDataPublisher
 if TYPE_CHECKING:
     from publisher.core import Publisher
     from vehicle_info import VehicleInfo
+
+LOG = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -82,5 +85,26 @@ class MessagePublisher(
                 value=message.vin,
             )
 
+            self.__publish_message_event(message)
+
             return MessagePublisherProcessingResult(processed=True)
         return MessagePublisherProcessingResult(processed=False)
+
+    def __publish_message_event(self, message: MessageEntity) -> None:
+        try:
+            self._publish(
+                topic=mqtt_topics.EVENTS_VEHICLE_MESSAGE,
+                value={
+                    "event_type": "vehicle_message",
+                    "title": message.title or "",
+                    "content": message.content or "",
+                    "message_type": message.messageType or "",
+                    "sender": message.sender or "",
+                    "vin": message.vin or "",
+                },
+            )
+        except Exception:
+            LOG.warning(
+                "Failed to publish vehicle message event",
+                exc_info=True,
+            )

--- a/src/status_publisher/message.py
+++ b/src/status_publisher/message.py
@@ -9,6 +9,7 @@ from saic_ismart_client_ng.api.message import MessageEntity
 
 import mqtt_topics
 from status_publisher import VehicleDataPublisher
+from utils import ensure_datetime_aware
 
 if TYPE_CHECKING:
     from publisher.core import Publisher
@@ -16,13 +17,6 @@ if TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 _EPOCH_MIN = datetime.min.replace(tzinfo=UTC)
-
-
-def _ensure_aware(dt: datetime) -> datetime:
-    """Return *dt* with UTC tzinfo if it is naive, otherwise unchanged."""
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=UTC)
-    return dt
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -41,7 +35,7 @@ class MessagePublisher(
 
     @override
     def publish(self, message: MessageEntity) -> MessagePublisherProcessingResult:
-        msg_time = _ensure_aware(message.message_time)
+        msg_time = ensure_datetime_aware(message.message_time)
         if (
             self.__last_car_vehicle_message == _EPOCH_MIN
             or msg_time > self.__last_car_vehicle_message

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,6 +58,13 @@ def get_gateway_version() -> str:
         return os.environ.get("RELEASE_VERSION", "unknown")
 
 
+def ensure_datetime_aware(dt: datetime) -> datetime:
+    """Return *dt* with UTC tzinfo if it is naive, otherwise unchanged."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
 def datetime_to_str(dt: datetime) -> str:
     return datetime.astimezone(dt, tz=UTC).isoformat()
 

--- a/tests/status_publisher/test_message_publisher.py
+++ b/tests/status_publisher/test_message_publisher.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+import unittest
+
+from saic_ismart_client_ng.api.message import MessageEntity
+from saic_ismart_client_ng.api.vehicle.schema import VinInfo
+
+from configuration import Configuration
+import mqtt_topics
+from status_publisher.message import MessagePublisher
+from tests.mocks import MessageCapturingConsolePublisher
+from vehicle_info import VehicleInfo
+
+VIN = "vin_test_000000000"
+VEHICLE_PREFIX = f"vehicles/{VIN}"
+EVENT_TOPIC = f"{VEHICLE_PREFIX}/{mqtt_topics.EVENTS_VEHICLE_MESSAGE}"
+
+
+def _make_publisher() -> tuple[MessagePublisher, MessageCapturingConsolePublisher]:
+    config = Configuration()
+    config.anonymized_publishing = False
+    capturing_publisher = MessageCapturingConsolePublisher(config)
+    vin_info = VinInfo()
+    vin_info.vin = VIN
+    vehicle_info = VehicleInfo(vin_info, None)
+    msg_publisher = MessagePublisher(vehicle_info, capturing_publisher, VEHICLE_PREFIX)
+    return msg_publisher, capturing_publisher
+
+
+def _make_message(
+    *,
+    message_id: str = "msg_001",
+    title: str = "Test Alert",
+    content: str = "Your vehicle has been started",
+    message_type: str = "323",
+    sender: str = "iSMART",
+    vin: str = VIN,
+    message_time: str = "2026-03-14 10:00:00",
+) -> MessageEntity:
+    return MessageEntity(
+        messageId=message_id,
+        title=title,
+        content=content,
+        messageType=message_type,
+        sender=sender,
+        vin=vin,
+        messageTime=message_time,
+    )
+
+
+def _get_event(capturing: MessageCapturingConsolePublisher) -> dict[str, Any]:
+    raw = capturing.map[EVENT_TOPIC]
+    result: dict[str, Any] = json.loads(raw)
+    return result
+
+
+class TestMessageEventPublished(unittest.TestCase):
+    def test_new_message_publishes_event(self) -> None:
+        publisher, capturing = _make_publisher()
+
+        result = publisher.publish(_make_message())
+
+        assert result.processed is True
+        assert EVENT_TOPIC in capturing.map
+        event = _get_event(capturing)
+        assert event["event_type"] == "vehicle_message"
+        assert event["title"] == "Test Alert"
+        assert event["content"] == "Your vehicle has been started"
+        assert event["message_type"] == "323"
+        assert event["sender"] == "iSMART"
+        assert event["vin"] == VIN
+
+    def test_duplicate_message_not_published(self) -> None:
+        publisher, capturing = _make_publisher()
+        msg = _make_message()
+
+        publisher.publish(msg)
+        capturing.map.clear()
+
+        result = publisher.publish(msg)
+
+        assert result.processed is False
+        assert EVENT_TOPIC not in capturing.map
+
+    def test_newer_message_publishes_event(self) -> None:
+        publisher, capturing = _make_publisher()
+
+        publisher.publish(_make_message(message_time="2026-03-14 10:00:00"))
+        capturing.map.clear()
+
+        result = publisher.publish(
+            _make_message(
+                message_id="msg_002",
+                title="Second Alert",
+                message_time="2026-03-14 11:00:00",
+            )
+        )
+
+        assert result.processed is True
+        event = _get_event(capturing)
+        assert event["title"] == "Second Alert"
+
+    def test_older_message_not_published(self) -> None:
+        publisher, capturing = _make_publisher()
+
+        publisher.publish(_make_message(message_time="2026-03-14 10:00:00"))
+        capturing.map.clear()
+
+        result = publisher.publish(
+            _make_message(
+                message_id="msg_old",
+                message_time="2026-03-14 09:00:00",
+            )
+        )
+
+        assert result.processed is False
+        assert EVENT_TOPIC not in capturing.map
+
+
+class TestMessageEventPayload(unittest.TestCase):
+    def test_none_fields_become_empty_strings(self) -> None:
+        publisher, capturing = _make_publisher()
+
+        msg = MessageEntity(
+            messageId="msg_none",
+            messageTime="2026-03-14 10:00:00",
+        )
+        publisher.publish(msg)
+
+        event = _get_event(capturing)
+        assert event["title"] == ""
+        assert event["content"] == ""
+        assert event["message_type"] == ""
+        assert event["sender"] == ""
+        assert event["vin"] == ""
+
+    def test_event_payload_keys(self) -> None:
+        publisher, capturing = _make_publisher()
+
+        publisher.publish(_make_message())
+
+        event = _get_event(capturing)
+        assert set(event.keys()) == {
+            "event_type",
+            "title",
+            "content",
+            "message_type",
+            "sender",
+            "vin",
+        }

--- a/tests/status_publisher/test_message_publisher.py
+++ b/tests/status_publisher/test_message_publisher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 import unittest
+from unittest.mock import patch
 
 from saic_ismart_client_ng.api.message import MessageEntity
 from saic_ismart_client_ng.api.vehicle.schema import VinInfo
@@ -150,3 +151,22 @@ class TestMessageEventPayload(unittest.TestCase):
             "sender",
             "vin",
         }
+
+
+class TestMessageEventResilience(unittest.TestCase):
+    def test_event_publish_failure_does_not_break_processing(self) -> None:
+        publisher, capturing = _make_publisher()
+        original_publish = publisher._publish_directly
+
+        def failing_publish(*, topic: str, value: Any) -> bool:
+            if mqtt_topics.EVENTS_VEHICLE_MESSAGE in topic:
+                raise RuntimeError("MQTT down")
+            return original_publish(topic=topic, value=value)
+
+        with patch.object(publisher, "_publish_directly", side_effect=failing_publish):
+            result = publisher.publish(_make_message())
+
+        assert result.processed is True
+        assert EVENT_TOPIC not in capturing.map
+        time_topic = f"{VEHICLE_PREFIX}/{mqtt_topics.INFO_LAST_MESSAGE_TIME}"
+        assert time_topic in capturing.map

--- a/tests/status_publisher/test_message_publisher.py
+++ b/tests/status_publisher/test_message_publisher.py
@@ -158,10 +158,10 @@ class TestMessageEventResilience(unittest.TestCase):
         publisher, capturing = _make_publisher()
         original_publish = publisher._publish_directly
 
-        def failing_publish(*, topic: str, value: Any) -> bool:
-            if mqtt_topics.EVENTS_VEHICLE_MESSAGE in topic:
+        def failing_publish(**kwargs: Any) -> bool:
+            if mqtt_topics.EVENTS_VEHICLE_MESSAGE in kwargs["topic"]:
                 raise RuntimeError("MQTT down")
-            return original_publish(topic=topic, value=value)
+            return original_publish(**kwargs)
 
         with patch.object(publisher, "_publish_directly", side_effect=failing_publish):
             result = publisher.publish(_make_message())


### PR DESCRIPTION
## Summary
- Adds a Home Assistant [MQTT Event entity](https://www.home-assistant.io/integrations/event.mqtt/) (`event.vehicle_message`) that fires when a new message arrives from the car
- Event payload includes `title`, `content`, `message_type`, `sender`, and `vin` for use in HA automations
- Deduplication is handled by the existing `MessagePublisher` timestamp guard — only genuinely new messages fire the event
- Published alongside existing per-field `info/lastMessage/*` sensors

## Test plan
- [x] 6 tests covering: new message fires event, duplicate/older messages don't, newer messages do, None fields become empty strings, payload structure
- [x] `ruff check`, `poetry run mypy`, `pytest` — all pass (161 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)