### PR TITLE
fix: publish window entities as binary_sensors instead of switches

### DIFF
--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -473,7 +473,9 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             device_class="window",
         )
         if self.__vin_info.has_sunroof:
-            self._publish_binary_sensor(mqtt_topics.WINDOWS_SUN_ROOF, "Sun roof")
+            self._publish_binary_sensor(
+                mqtt_topics.WINDOWS_SUN_ROOF, "Sun roof", device_class="window"
+            )
         else:
             self.__unpublish_ha_discovery_message("binary_sensor", "Sun roof")
 

--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -451,15 +451,30 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
         )
 
     def __publish_windows_sensors(self) -> None:
-        self._publish_switch(mqtt_topics.WINDOWS_DRIVER, "Window driver")
-        self._publish_switch(mqtt_topics.WINDOWS_PASSENGER, "Window passenger")
-        self._publish_switch(mqtt_topics.WINDOWS_REAR_LEFT, "Window rear left")
-        self._publish_switch(mqtt_topics.WINDOWS_REAR_RIGHT, "Window rear right")
+        self.__unpublish_ha_discovery_message("switch", "Window driver")
+        self.__unpublish_ha_discovery_message("switch", "Window passenger")
+        self.__unpublish_ha_discovery_message("switch", "Window rear left")
+        self.__unpublish_ha_discovery_message("switch", "Window rear right")
+        self.__unpublish_ha_discovery_message("switch", "Sun roof")
+        self._publish_binary_sensor(
+            mqtt_topics.WINDOWS_DRIVER, "Window driver", device_class="window"
+        )
+        self._publish_binary_sensor(
+            mqtt_topics.WINDOWS_PASSENGER, "Window passenger", device_class="window"
+        )
+        self._publish_binary_sensor(
+            mqtt_topics.WINDOWS_REAR_LEFT,
+            "Window rear left",
+            device_class="window",
+        )
+        self._publish_binary_sensor(
+            mqtt_topics.WINDOWS_REAR_RIGHT,
+            "Window rear right",
+            device_class="window",
+        )
         if self.__vin_info.has_sunroof:
-            self._publish_switch(mqtt_topics.WINDOWS_SUN_ROOF, "Sun roof")
             self._publish_binary_sensor(mqtt_topics.WINDOWS_SUN_ROOF, "Sun roof")
         else:
-            self.__unpublish_ha_discovery_message("switch", "Sun roof")
             self.__unpublish_ha_discovery_message("binary_sensor", "Sun roof")
 
     def __publish_ccu_sensors(self) -> None:

--- a/tests/test_ha_discovery_windows.py
+++ b/tests/test_ha_discovery_windows.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from saic_ismart_client_ng.api.vehicle.schema import (
+    VehicleModelConfiguration,
+    VinInfo,
+)
+
+from configuration import Configuration
+from integrations.home_assistant.discovery import HomeAssistantDiscovery
+from vehicle import VehicleState
+from vehicle_info import VehicleInfo
+
+from .common_mocks import VIN
+from .mocks import MessageCapturingConsolePublisher
+
+
+class TestHaDiscoveryWindows(unittest.TestCase):
+    """Test that window entities are published as binary_sensors, not switches."""
+
+    def _make_discovery(
+        self, *, has_sunroof: bool = False
+    ) -> tuple[HomeAssistantDiscovery, MessageCapturingConsolePublisher]:
+        config = Configuration()
+        config.anonymized_publishing = False
+        config.ha_discovery_prefix = "homeassistant"
+        publisher = MessageCapturingConsolePublisher(config)
+        vin_info = VinInfo()
+        vin_info.vin = VIN
+        vin_info.series = "EH32 S"
+        vin_info.modelName = "MG4 Electric"
+        vin_info.modelYear = "2022"
+        configs = [
+            VehicleModelConfiguration("BATTERY", "BATTERY", "1"),
+            VehicleModelConfiguration("BType", "Battery", "1"),
+            VehicleModelConfiguration(
+                "S35", "Sunroof", "1" if has_sunroof else "0"
+            ),
+        ]
+        vin_info.vehicleModelConfiguration = configs
+        vehicle_info = VehicleInfo(vin_info, None)
+        account_prefix = f"/vehicles/{VIN}"
+        scheduler = BlockingScheduler()
+        vehicle_state = VehicleState(publisher, scheduler, account_prefix, vehicle_info)
+        # Make vehicle state complete so discovery publishes
+        vehicle_state.refresh_period_active = 30
+        vehicle_state.refresh_period_inactive = 120
+        vehicle_state.refresh_period_after_shutdown = 60
+        vehicle_state.refresh_period_inactive_grace = 600
+        vehicle_state.refresh_mode = "periodic"
+        discovery = HomeAssistantDiscovery(vehicle_state, vehicle_info, config)
+        return discovery, publisher
+
+    def _discovery_topics(self, publisher: MessageCapturingConsolePublisher) -> set[str]:
+        return set(publisher.map.keys())
+
+    def test_windows_published_as_binary_sensors(self) -> None:
+        discovery, publisher = self._make_discovery()
+        discovery.publish_ha_discovery_messages()
+
+        topics = self._discovery_topics(publisher)
+        window_names = [
+            "window_driver",
+            "window_passenger",
+            "window_rear_left",
+            "window_rear_right",
+        ]
+        for name in window_names:
+            binary_sensor_topic = (
+                f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_{name}/config"
+            )
+            assert binary_sensor_topic in topics, (
+                f"Expected binary_sensor discovery for {name}"
+            )
+            # Verify the payload has no command_topic (read-only)
+            payload = json.loads(publisher.map[binary_sensor_topic])
+            assert "command_topic" not in payload
+            assert payload["device_class"] == "window"
+
+    def test_windows_not_published_as_switches(self) -> None:
+        discovery, publisher = self._make_discovery()
+        discovery.publish_ha_discovery_messages()
+
+        topics = self._discovery_topics(publisher)
+        window_names = [
+            "window_driver",
+            "window_passenger",
+            "window_rear_left",
+            "window_rear_right",
+        ]
+        for name in window_names:
+            switch_topic = f"homeassistant/switch/{VIN}_mg/{VIN}_{name}/config"
+            if switch_topic in topics:
+                # Should be an empty unpublish message
+                assert publisher.map[switch_topic] == "", (
+                    f"Switch for {name} should be unpublished (empty payload)"
+                )
+
+    def test_sunroof_published_as_binary_sensor_when_supported(self) -> None:
+        discovery, publisher = self._make_discovery(has_sunroof=True)
+        discovery.publish_ha_discovery_messages()
+
+        topics = self._discovery_topics(publisher)
+        sunroof_topic = (
+            f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_sun_roof/config"
+        )
+        assert sunroof_topic in topics
+
+    def test_sunroof_unpublished_when_not_supported(self) -> None:
+        discovery, publisher = self._make_discovery(has_sunroof=False)
+        discovery.publish_ha_discovery_messages()
+
+        topics = self._discovery_topics(publisher)
+        sunroof_binary = (
+            f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_sun_roof/config"
+        )
+        if sunroof_binary in topics:
+            assert publisher.map[sunroof_binary] == ""

--- a/tests/test_ha_discovery_windows.py
+++ b/tests/test_ha_discovery_windows.py
@@ -11,7 +11,7 @@ from saic_ismart_client_ng.api.vehicle.schema import (
 
 from configuration import Configuration
 from integrations.home_assistant.discovery import HomeAssistantDiscovery
-from vehicle import VehicleState
+from vehicle import RefreshMode, VehicleState
 from vehicle_info import VehicleInfo
 
 from .common_mocks import VIN
@@ -57,7 +57,7 @@ class TestHaDiscoveryWindows(unittest.TestCase):
         vehicle_state.refresh_period_inactive = 120
         vehicle_state.refresh_period_after_shutdown = 60
         vehicle_state.refresh_period_inactive_grace = 600
-        vehicle_state.refresh_mode = "periodic"
+        vehicle_state.refresh_mode = RefreshMode.PERIODIC
         discovery = HomeAssistantDiscovery(vehicle_state, vehicle_info, config)
         return discovery, publisher
 

--- a/tests/test_ha_discovery_windows.py
+++ b/tests/test_ha_discovery_windows.py
@@ -17,6 +17,13 @@ from vehicle_info import VehicleInfo
 from .common_mocks import VIN
 from .mocks import MessageCapturingConsolePublisher
 
+WINDOW_NAMES = [
+    "window_driver",
+    "window_passenger",
+    "window_rear_left",
+    "window_rear_right",
+]
+
 
 class TestHaDiscoveryWindows(unittest.TestCase):
     """Test that window entities are published as binary_sensors, not switches."""
@@ -54,68 +61,58 @@ class TestHaDiscoveryWindows(unittest.TestCase):
         discovery = HomeAssistantDiscovery(vehicle_state, vehicle_info, config)
         return discovery, publisher
 
-    def _discovery_topics(self, publisher: MessageCapturingConsolePublisher) -> set[str]:
-        return set(publisher.map.keys())
-
     def test_windows_published_as_binary_sensors(self) -> None:
         discovery, publisher = self._make_discovery()
         discovery.publish_ha_discovery_messages()
 
-        topics = self._discovery_topics(publisher)
-        window_names = [
-            "window_driver",
-            "window_passenger",
-            "window_rear_left",
-            "window_rear_right",
-        ]
-        for name in window_names:
+        for name in WINDOW_NAMES:
             binary_sensor_topic = (
                 f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_{name}/config"
             )
-            assert binary_sensor_topic in topics, (
+            assert binary_sensor_topic in publisher.map, (
                 f"Expected binary_sensor discovery for {name}"
             )
-            # Verify the payload has no command_topic (read-only)
             payload = json.loads(publisher.map[binary_sensor_topic])
             assert "command_topic" not in payload
             assert payload["device_class"] == "window"
 
-    def test_windows_not_published_as_switches(self) -> None:
+    def test_old_window_switches_are_unpublished(self) -> None:
         discovery, publisher = self._make_discovery()
         discovery.publish_ha_discovery_messages()
 
-        topics = self._discovery_topics(publisher)
-        window_names = [
-            "window_driver",
-            "window_passenger",
-            "window_rear_left",
-            "window_rear_right",
-        ]
-        for name in window_names:
+        for name in WINDOW_NAMES:
             switch_topic = f"homeassistant/switch/{VIN}_mg/{VIN}_{name}/config"
-            if switch_topic in topics:
-                # Should be an empty unpublish message
-                assert publisher.map[switch_topic] == "", (
-                    f"Switch for {name} should be unpublished (empty payload)"
-                )
+            assert switch_topic in publisher.map, (
+                f"Expected unpublish message for switch {name}"
+            )
+            assert publisher.map[switch_topic] == "", (
+                f"Switch for {name} should be unpublished (empty payload)"
+            )
+        # Sunroof switch is also always unpublished
+        sunroof_switch = f"homeassistant/switch/{VIN}_mg/{VIN}_sun_roof/config"
+        assert sunroof_switch in publisher.map
+        assert publisher.map[sunroof_switch] == ""
 
     def test_sunroof_published_as_binary_sensor_when_supported(self) -> None:
         discovery, publisher = self._make_discovery(has_sunroof=True)
         discovery.publish_ha_discovery_messages()
 
-        topics = self._discovery_topics(publisher)
         sunroof_topic = (
             f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_sun_roof/config"
         )
-        assert sunroof_topic in topics
+        assert sunroof_topic in publisher.map
+        payload = json.loads(publisher.map[sunroof_topic])
+        assert "command_topic" not in payload
+        assert payload["device_class"] == "window"
 
     def test_sunroof_unpublished_when_not_supported(self) -> None:
         discovery, publisher = self._make_discovery(has_sunroof=False)
         discovery.publish_ha_discovery_messages()
 
-        topics = self._discovery_topics(publisher)
         sunroof_binary = (
             f"homeassistant/binary_sensor/{VIN}_mg/{VIN}_sun_roof/config"
         )
-        if sunroof_binary in topics:
-            assert publisher.map[sunroof_binary] == ""
+        assert sunroof_binary in publisher.map, (
+            "Expected unpublish message for binary_sensor Sun roof"
+        )
+        assert publisher.map[sunroof_binary] == ""


### PR DESCRIPTION
## Summary
- Changes window HA discovery from `switch` to `binary_sensor` with `device_class=window`, since remote window control is not implemented and toggling the switches caused errors
- Unpublishes old switch discovery entries on startup for a clean migration path
- Adds tests for the new discovery behavior

Closes #252

## Test plan
- [x] All 159 existing tests pass
- [x] 4 new tests verify windows are binary_sensors, old switches are unpublished, and sunroof conditional logic works
- [ ] Manual: verify HA removes old `switch.window_*` entities and creates `binary_sensor.window_*` entities after gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)