### PR TITLE
chore: add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+ci:
+  autofix_prs: false
+  skip:
+    # These steps run in the CI workflow already. Keep in sync.
+    - mypy
+
+default_language_version:
+  python: python3.13
+
+repos:
+  - repo: https://github.com/python-poetry/poetry
+    rev: '2.1.3'
+    hooks:
+      - id: poetry-check
+      - id: poetry-lock
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.0
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+          - --unsafe-fixes
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: mypy
+        name: Check with mypy
+        entry: poetry run mypy
+        language: system
+        types:
+          - python
+        require_serial: true
+      - id: pytest
+        name: Run pytest
+        entry: poetry run pytest tests
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-added-large-files


### PR DESCRIPTION
## Summary

Adds a \`.pre-commit-config.yaml\` so contributors can run the same checks the CI workflow runs (\`mypy\`, \`ruff check\`, \`pytest\`) before pushing. Mirrors the setup in the sister repo [\`saic-python-client-ng\`](https://github.com/SAIC-iSmart-API/saic-python-client-ng/blob/main/.pre-commit-config.yaml) so the two projects stay consistent.

### Hooks

| Stage | Hooks |
| --- | --- |
| pre-commit | \`poetry-check\`, \`poetry-lock\`, \`ruff\` (with \`--fix --unsafe-fixes\`), \`ruff-format\`, \`mypy\`, \`check-yaml\`, \`check-added-large-files\` |
| pre-push | \`pytest tests\` |

### Deliberate differences vs. \`saic-python-client-ng\`

- **No \`pylint\`** — this repo dropped pylint in favour of ruff and mypy in 0.10.0.
- **\`pytest\` is wired to \`pre-push\`** rather than skipped entirely. Commits stay fast; pushes verify the test suite. Locally CI-equivalent without waiting for GitHub.

### To enable locally

\`\`\`
pipx install pre-commit
pre-commit install --hook-type pre-commit --hook-type pre-push
\`\`\`

## Test plan

- [x] \`pre-commit run --all-files\` passes on a clean checkout
- [x] \`pre-commit run --hook-stage pre-push\` runs the full pytest suite (177 tests pass)
- [x] CI passes