### PR TITLE
fix: persist HA-driven gateway settings via retained /set commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+
+* Persist user-set HA gateway entities across gateway restarts by retaining
+  their `/set` commands on the MQTT broker (refresh mode, all four refresh
+  periods, and total battery capacity). On reconnect the existing command-
+  dispatch path replays the retained value before `configure_missing()` would
+  apply config defaults. A retained one-shot refresh mode (`force`,
+  `charging_detection`) is dropped on replay so a single-shot poll does not
+  fire on every restart.
+
+  Note: on first upgrade only entities you change *after* the upgrade become
+  persistent. Existing retained STATE values on the broker are not converted
+  into retained `/set` commands.
+
 ## 0.11.0
 
 ### Added

--- a/src/handlers/command/base.py
+++ b/src/handlers/command/base.py
@@ -45,6 +45,19 @@ class CommandHandlerBase(metaclass=ABCMeta):
         return cls.__name__
 
     @classmethod
+    def is_replayable_when_retained(cls) -> bool:
+        """Whether the dispatcher may invoke this handler with retained=True.
+
+        Default False: action-bearing commands (charging start/stop, locks,
+        climate, FORCE refresh, etc.) would re-fire on every gateway restart
+        if their `/set` topic was retained on the broker, so the dispatcher
+        drops the replay before the handler runs. Override to True only on
+        idempotent value-bearing handlers whose HA discovery payload also
+        declares `retain: true`.
+        """
+        return False
+
+    @classmethod
     @abstractmethod
     def topic(cls) -> str:
         raise NotImplementedError

--- a/src/handlers/command/base.py
+++ b/src/handlers/command/base.py
@@ -50,7 +50,9 @@ class CommandHandlerBase(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def handle(self, payload: str) -> CommandProcessingResult:
+    async def handle(
+        self, payload: str, *, retained: bool = False
+    ) -> CommandProcessingResult:
         raise NotImplementedError
 
     @property
@@ -84,7 +86,12 @@ class MultiValuedCommandHandler[T](CommandHandlerBase, metaclass=ABCMeta):
         return False
 
     @override
-    async def handle(self, payload: str) -> CommandProcessingResult:
+    async def handle(
+        self,
+        payload: str,
+        *,
+        retained: bool = False,
+    ) -> CommandProcessingResult:
         normalized_payload = payload.strip().lower()
 
         if len(normalized_payload) == 0 and not self.supports_empty_payload:
@@ -113,7 +120,12 @@ class BooleanCommandHandler[T](CommandHandlerBase, metaclass=ABCMeta):
         pass
 
     @override
-    async def handle(self, payload: str) -> CommandProcessingResult:
+    async def handle(
+        self,
+        payload: str,
+        *,
+        retained: bool = False,
+    ) -> CommandProcessingResult:
         normalized_payload = payload.strip().lower()
 
         if len(normalized_payload) == 0:
@@ -145,7 +157,12 @@ class PayloadConvertingCommandHandler[T](CommandHandlerBase, metaclass=ABCMeta):
         return False
 
     @override
-    async def handle(self, payload: str) -> CommandProcessingResult:
+    async def handle(
+        self,
+        payload: str,
+        *,
+        retained: bool = False,
+    ) -> CommandProcessingResult:
         if len(payload.strip()) == 0 and not self.supports_empty_payload:
             return RESULT_DO_NOTHING
 

--- a/src/handlers/command/drivetrain/drivetrain_total_battery_capacity.py
+++ b/src/handlers/command/drivetrain/drivetrain_total_battery_capacity.py
@@ -16,6 +16,11 @@ LOG = logging.getLogger(__name__)
 class DrivetrainTotalBatteryCapacitySetCommand(FloatCommandHandler):
     @classmethod
     @override
+    def is_replayable_when_retained(cls) -> bool:
+        return True
+
+    @classmethod
+    @override
     def topic(cls) -> str:
         return mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY_SET
 

--- a/src/handlers/command/gateway/refresh_mode.py
+++ b/src/handlers/command/gateway/refresh_mode.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import logging
 from typing import override
 
+from exceptions import MqttGatewayException
 from handlers.command.base import (
     RESULT_DO_NOTHING,
     CommandProcessingResult,
     PayloadConvertingCommandHandler,
 )
 import mqtt_topics
-from vehicle import RefreshMode
+from vehicle import ONE_SHOT_REFRESH_MODES, RefreshMode
+
+LOG = logging.getLogger(__name__)
 
 
 class RefreshModeCommand(PayloadConvertingCommandHandler[RefreshMode]):
@@ -22,6 +26,27 @@ class RefreshModeCommand(PayloadConvertingCommandHandler[RefreshMode]):
     def convert_payload(payload: str) -> RefreshMode:
         normalized_payload = payload.strip().lower()
         return RefreshMode.get(normalized_payload)
+
+    @override
+    async def handle(
+        self, payload: str, *, retained: bool = False
+    ) -> CommandProcessingResult:
+        if len(payload.strip()) == 0:
+            return RESULT_DO_NOTHING
+        try:
+            refresh_mode = self.convert_payload(payload)
+        except Exception as e:
+            msg = f"Error converting payload {payload} for command {self.name()}"
+            raise MqttGatewayException(msg) from e
+        if retained and refresh_mode in ONE_SHOT_REFRESH_MODES:
+            # Retained one-shot modes would re-fire on every gateway restart.
+            LOG.info(
+                "Dropping retained one-shot refresh mode %s for VIN %s",
+                refresh_mode.value,
+                self.vin,
+            )
+            return RESULT_DO_NOTHING
+        return await self.handle_typed_payload(refresh_mode)
 
     @override
     async def handle_typed_payload(

--- a/src/handlers/command/gateway/refresh_mode.py
+++ b/src/handlers/command/gateway/refresh_mode.py
@@ -31,7 +31,7 @@ class RefreshModeCommand(PayloadConvertingCommandHandler[RefreshMode]):
     async def handle(
         self, payload: str, *, retained: bool = False
     ) -> CommandProcessingResult:
-        if len(payload.strip()) == 0:
+        if len(payload.strip()) == 0 and not self.supports_empty_payload:
             return RESULT_DO_NOTHING
         try:
             refresh_mode = self.convert_payload(payload)

--- a/src/handlers/command/gateway/refresh_mode.py
+++ b/src/handlers/command/gateway/refresh_mode.py
@@ -18,6 +18,12 @@ LOG = logging.getLogger(__name__)
 class RefreshModeCommand(PayloadConvertingCommandHandler[RefreshMode]):
     @classmethod
     @override
+    def is_replayable_when_retained(cls) -> bool:
+        # OFF / PERIODIC are persistent user choices; one-shots dropped in handle().
+        return True
+
+    @classmethod
+    @override
     def topic(cls) -> str:
         return mqtt_topics.REFRESH_MODE_SET
 

--- a/src/handlers/command/gateway/refresh_period.py
+++ b/src/handlers/command/gateway/refresh_period.py
@@ -13,6 +13,11 @@ import mqtt_topics
 class RefreshPeriodActiveCommand(IntCommandHandler):
     @classmethod
     @override
+    def is_replayable_when_retained(cls) -> bool:
+        return True
+
+    @classmethod
+    @override
     def topic(cls) -> str:
         return mqtt_topics.REFRESH_PERIOD_ACTIVE_SET
 
@@ -23,6 +28,11 @@ class RefreshPeriodActiveCommand(IntCommandHandler):
 
 
 class RefreshPeriodInactiveCommand(IntCommandHandler):
+    @classmethod
+    @override
+    def is_replayable_when_retained(cls) -> bool:
+        return True
+
     @classmethod
     @override
     def topic(cls) -> str:
@@ -37,6 +47,11 @@ class RefreshPeriodInactiveCommand(IntCommandHandler):
 class RefreshPeriodInactiveGraceCommand(IntCommandHandler):
     @classmethod
     @override
+    def is_replayable_when_retained(cls) -> bool:
+        return True
+
+    @classmethod
+    @override
     def topic(cls) -> str:
         return mqtt_topics.REFRESH_PERIOD_INACTIVE_GRACE_SET
 
@@ -47,6 +62,11 @@ class RefreshPeriodInactiveGraceCommand(IntCommandHandler):
 
 
 class RefreshPeriodAfterShutdownCommand(IntCommandHandler):
+    @classmethod
+    @override
+    def is_replayable_when_retained(cls) -> bool:
+        return True
+
     @classmethod
     @override
     def topic(cls) -> str:

--- a/src/handlers/vehicle.py
+++ b/src/handlers/vehicle.py
@@ -241,10 +241,9 @@ class VehicleHandler:
         )
 
     def __should_complete_configuration(self, start_time: datetime.datetime) -> bool:
-        return (
-            not self.vehicle_state.is_complete()
-            and datetime.datetime.now(tz=datetime.UTC) > start_time + datetime.timedelta(seconds=10)
-        )
+        return not self.vehicle_state.is_complete() and datetime.datetime.now(
+            tz=datetime.UTC
+        ) > start_time + datetime.timedelta(seconds=10)
 
     def __refresh_openwb(
         self,
@@ -334,8 +333,12 @@ class VehicleHandler:
         )
         return scheduled_battery_heating_status
 
-    async def handle_mqtt_command(self, *, topic: str, payload: str) -> None:
-        await self.__command_handler.handle_mqtt_command(topic=topic, payload=payload)
+    async def handle_mqtt_command(
+        self, *, topic: str, payload: str, retained: bool = False
+    ) -> None:
+        await self.__command_handler.handle_mqtt_command(
+            topic=topic, payload=payload, retained=retained
+        )
 
     def __setup_ha_discovery(
         self, vehicle_state: VehicleState, vin_info: VehicleInfo, config: Configuration
@@ -343,7 +346,6 @@ class VehicleHandler:
         if self.configuration.ha_discovery_enabled:
             return HomeAssistantDiscovery(vehicle_state, vin_info, config)
         return None
-
 
     def handle_charging_station_energy_imported(
         self, imported_energy_wh: float

--- a/src/handlers/vehicle_command.py
+++ b/src/handlers/vehicle_command.py
@@ -123,6 +123,19 @@ class VehicleCommandHandler:
         topic_no_global = analyzed_topic.command_no_global
         result_topic = analyzed_topic.response_no_global
 
+        if retained and not handler.is_replayable_when_retained():
+            # A retained `/set` for an action-bearing command would re-fire the
+            # action on every gateway restart. Drop it before invoking the
+            # handler. Only handlers that explicitly opt in via
+            # ``replayable_when_retained = True`` see retained replays.
+            LOG.warning(
+                "Dropping retained replay for non-replayable command %s on %s; "
+                "this command should not have been published with retain=true",
+                handler.name(),
+                topic,
+            )
+            return
+
         try:
             execution_result = await handler.handle(payload, retained=retained)
             self.publisher.publish_str(result_topic, "Success")

--- a/src/handlers/vehicle_command.py
+++ b/src/handlers/vehicle_command.py
@@ -91,7 +91,9 @@ class VehicleCommandHandler:
                 command,
             )
 
-    async def handle_mqtt_command(self, *, topic: str, payload: str) -> None:
+    async def handle_mqtt_command(
+        self, *, topic: str, payload: str, retained: bool = False
+    ) -> None:
         analyzed_topic = self.__get_command_topics(topic)
         handler = self.__command_handlers.get(analyzed_topic.command_no_vin)
         if not handler:
@@ -103,7 +105,10 @@ class VehicleCommandHandler:
             )
         else:
             await self.__execute_mqtt_command_handler(
-                handler=handler, payload=payload, analyzed_topic=analyzed_topic
+                handler=handler,
+                payload=payload,
+                analyzed_topic=analyzed_topic,
+                retained=retained,
             )
 
     async def __execute_mqtt_command_handler(
@@ -112,19 +117,20 @@ class VehicleCommandHandler:
         handler: CommandHandlerBase,
         payload: str,
         analyzed_topic: _MqttCommandTopic,
+        retained: bool,
     ) -> None:
         topic = analyzed_topic.command_no_vin
         topic_no_global = analyzed_topic.command_no_global
         result_topic = analyzed_topic.response_no_global
 
         try:
-            execution_result = await handler.handle(payload)
+            execution_result = await handler.handle(payload, retained=retained)
             self.publisher.publish_str(result_topic, "Success")
             if execution_result.force_refresh:
                 self.vehicle_state.set_refresh_mode(
                     RefreshMode.FORCE, f"after command execution on topic {topic}"
                 )
-            if execution_result.clear_command:
+            if execution_result.clear_command and not retained:
                 self.publisher.clear_topic(topic_no_global)
         except MqttGatewayException as e:
             self.__report_command_failure(
@@ -145,14 +151,14 @@ class VehicleCommandHandler:
                 )
                 return
             try:
-                execution_result = await handler.handle(payload)
+                execution_result = await handler.handle(payload, retained=retained)
                 self.publisher.publish_str(result_topic, "Success")
                 if execution_result.force_refresh:
                     self.vehicle_state.set_refresh_mode(
                         RefreshMode.FORCE,
                         f"after command execution on topic {topic}",
                     )
-                if execution_result.clear_command:
+                if execution_result.clear_command and not retained:
                     self.publisher.clear_topic(topic_no_global)
             except Exception as retry_err:
                 self.__report_command_failure(

--- a/src/integrations/home_assistant/base.py
+++ b/src/integrations/home_assistant/base.py
@@ -46,14 +46,16 @@ class HomeAssistantDiscoveryBase(metaclass=abc.ABCMeta):
         enabled: bool = True,
         value_template: str = "{{ value }}",
         command_template: str = "{{ value }}",
+        retain: bool = False,
         icon: str | None = None,
         custom_availability: HaCustomAvailabilityConfig | None = None,
     ) -> str:
-        payload = {
+        payload: dict[str, Any] = {
             "state_topic": self._get_state_topic(topic),
             "command_topic": self._get_command_topic(topic),
             "value_template": value_template,
             "command_template": command_template,
+            "retain": str(retain).lower(),
             "options": options,
             "enabled_by_default": enabled,
         }

--- a/src/integrations/home_assistant/discovery.py
+++ b/src/integrations/home_assistant/discovery.py
@@ -167,6 +167,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             mode="box",
             min_value=0.0,
             step=0.001,
+            retain=True,
         )
 
         self._publish_sensor(
@@ -640,6 +641,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             value_template="{{ value }}",
             command_template="{{ value }}",
             icon="mdi:refresh",
+            retain=True,
             custom_availability=self.__system_availability_config,
         )
         self._publish_number(
@@ -651,6 +653,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             min_value=30,
             max_value=60 * 60,
             step=1,
+            retain=True,
             custom_availability=self.__system_availability_config,
         )
         self._publish_number(
@@ -662,6 +665,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             min_value=1 * 60 * 60,
             max_value=5 * 24 * 60 * 60,
             step=1,
+            retain=True,
             custom_availability=self.__system_availability_config,
         )
         self._publish_number(
@@ -673,6 +677,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             min_value=30,
             max_value=12 * 60 * 60,
             step=1,
+            retain=True,
             custom_availability=self.__system_availability_config,
         )
         self._publish_number(
@@ -684,6 +689,7 @@ class HomeAssistantDiscovery(HomeAssistantDiscoveryBase):
             min_value=30,
             max_value=12 * 60 * 60,
             step=1,
+            retain=True,
             custom_availability=self.__system_availability_config,
         )
         self._publish_sensor(

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -366,7 +366,7 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
                 topic=topic, payload=payload, retained=retained
             )
         elif retained:
-            LOG.info(
+            LOG.warning(
                 f"Retained command for unknown vin {vin} received on {topic};"
                 f" handler not yet registered, dropping replay"
             )

--- a/src/mqtt_gateway.py
+++ b/src/mqtt_gateway.py
@@ -255,7 +255,9 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
 
     def __create_vehicle_handler(self, vin_info: VinInfo) -> VehicleHandler:
         vin = vin_info.vin
-        total_battery_capacity = self.configuration.battery_capacity_map.get(vin, None) if vin else None
+        total_battery_capacity = (
+            self.configuration.battery_capacity_map.get(vin, None) if vin else None
+        )
         info = VehicleInfo(vin_info, total_battery_capacity)
         account_prefix = f"{self.configuration.saic_user}/{mqtt_topics.VEHICLES}/{vin}"
         vehicle_state = VehicleState(
@@ -356,11 +358,18 @@ class MqttGateway(MqttCommandListener, VehicleHandlerLocator):
 
     @override
     async def on_mqtt_command_received(
-        self, *, vin: str, topic: str, payload: str
+        self, *, vin: str, topic: str, payload: str, retained: bool = False
     ) -> None:
         vehicle_handler = self.get_vehicle_handler(vin)
         if vehicle_handler:
-            await vehicle_handler.handle_mqtt_command(topic=topic, payload=payload)
+            await vehicle_handler.handle_mqtt_command(
+                topic=topic, payload=payload, retained=retained
+            )
+        elif retained:
+            LOG.info(
+                f"Retained command for unknown vin {vin} received on {topic};"
+                f" handler not yet registered, dropping replay"
+            )
         else:
             LOG.debug(f"Command for unknown vin {vin} received")
 

--- a/src/publisher/core.py
+++ b/src/publisher/core.py
@@ -16,7 +16,7 @@ T = TypeVar("T")
 class MqttCommandListener(ABC):
     @abstractmethod
     async def on_mqtt_command_received(
-        self, *, vin: str, topic: str, payload: str
+        self, *, vin: str, topic: str, payload: str, retained: bool = False
     ) -> None:
         raise NotImplementedError("Should have implemented this")
 
@@ -187,7 +187,9 @@ class Publisher(ABC):
     def anonymize_device_id(self, device_id: str) -> str:
         elements = device_id.split("###", maxsplit=1)
         if len(elements) == 2:
-            return f"{self.anonymize_str(elements[0])}###{self.anonymize_str(elements[1])}"
+            return (
+                f"{self.anonymize_str(elements[0])}###{self.anonymize_str(elements[1])}"
+            )
         return self.anonymize_str(device_id)
 
     @staticmethod

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -151,7 +151,7 @@ class MqttPublisher(Publisher):
                 payload = payload.decode("utf-8")
             else:
                 payload = str(payload)
-            retained = bool(_properties.get("retain", 0)) if _properties else False
+            retained = bool(_properties.get("retain", 0))
             await self.__on_message_real(
                 topic=topic, payload=payload, retained=retained
             )

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -151,11 +151,16 @@ class MqttPublisher(Publisher):
                 payload = payload.decode("utf-8")
             else:
                 payload = str(payload)
-            await self.__on_message_real(topic=topic, payload=payload)
+            retained = bool(_properties.get("retain", 0)) if _properties else False
+            await self.__on_message_real(
+                topic=topic, payload=payload, retained=retained
+            )
         except Exception as e:
             LOG.exception(f"Error while processing MQTT message: {e}")
 
-    async def __on_message_real(self, *, topic: str, payload: str) -> None:
+    async def __on_message_real(
+        self, *, topic: str, payload: str, retained: bool
+    ) -> None:
         if topic in self.vin_by_charge_state_topic:
             LOG.debug(f"Received message over topic {topic} with payload {payload}")
             vin = self.vin_by_charge_state_topic[topic]
@@ -194,7 +199,7 @@ class MqttPublisher(Publisher):
             vin = self.get_vin_from_topic(topic)
             if self.command_listener is not None:
                 await self.command_listener.on_mqtt_command_received(
-                    vin=vin, topic=topic, payload=payload
+                    vin=vin, topic=topic, payload=payload, retained=retained
                 )
 
     async def __handle_imported_energy(self, topic: str, payload: str) -> None:

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -71,8 +71,10 @@ ONE_SHOT_REFRESH_MODES: Final[frozenset[RefreshMode]] = frozenset(
 )
 
 #: Refresh modes that are not valid at startup and must be replaced with PERIODIC.
+#: Only one-shot modes are coerced; OFF is a legitimate persistent user choice
+#: (restored from retained `/set` on reconnect) and must be preserved.
 INVALID_STARTUP_REFRESH_MODES: Final[frozenset[RefreshMode]] = frozenset(
-    {RefreshMode.OFF, RefreshMode.FORCE, RefreshMode.CHARGING_DETECTION}
+    {RefreshMode.FORCE, RefreshMode.CHARGING_DETECTION}
 )
 
 
@@ -108,13 +110,21 @@ class VehicleState:
         )
         self.vehicle: Final[VehicleInfo] = vin_info
         self.mqtt_vin_prefix = account_prefix
-        self.last_car_activity: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
-        self.last_successful_refresh: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
+        self.last_car_activity: datetime.datetime = datetime.datetime.min.replace(
+            tzinfo=datetime.UTC
+        )
+        self.last_successful_refresh: datetime.datetime = datetime.datetime.min.replace(
+            tzinfo=datetime.UTC
+        )
         self.__last_failed_refresh: datetime.datetime | None = None
         self.__failed_refresh_counter = 0
         self.__refresh_period_error = 30
-        self.last_car_shutdown: datetime.datetime = datetime.datetime.now(tz=datetime.UTC)
-        self.last_car_vehicle_message: datetime.datetime = datetime.datetime.min.replace(tzinfo=datetime.UTC)
+        self.last_car_shutdown: datetime.datetime = datetime.datetime.now(
+            tz=datetime.UTC
+        )
+        self.last_car_vehicle_message: datetime.datetime = (
+            datetime.datetime.min.replace(tzinfo=datetime.UTC)
+        )
         # treat high voltage battery as active, if we don't have any other information
         self.__hv_battery_active = True
         self.__hv_battery_active_from_car = True
@@ -128,8 +138,8 @@ class VehicleState:
         self.charge_current_limit: ChargeCurrentLimitCode | None = None
         self.refresh_period_charging = 0
         self.charge_polling_min_percent = charge_polling_min_percent
-        self.refresh_mode = RefreshMode.OFF
-        self.previous_refresh_mode = RefreshMode.OFF
+        self.refresh_mode = RefreshMode.PERIODIC
+        self.previous_refresh_mode = RefreshMode.PERIODIC
         self.__polling_phase: PollingPhase | None = None
         self.__remote_ac_temp: int | None = None
         self.__remote_ac_running: bool = False
@@ -243,7 +253,11 @@ class VehicleState:
             tz = self.__user_timezone
             if self.refresh_period_inactive_grace > 0:
                 # Add a grace period to the start time, so that the car is not woken up too early
-                now = datetime.datetime.now(tz=tz) if tz else datetime.datetime.now().astimezone()
+                now = (
+                    datetime.datetime.now(tz=tz)
+                    if tz
+                    else datetime.datetime.now().astimezone()
+                )
                 dt = now.replace(
                     hour=start_time.hour,
                     minute=start_time.minute,
@@ -426,20 +440,16 @@ class VehicleState:
             self.__publish_polling_phase(PollingPhase.ERROR_RECOVERY)
             return result
         if self.is_charging and self.refresh_period_charging > 0:
-            result = (
-                self.last_successful_refresh
-                < datetime.datetime.now(tz=datetime.UTC)
-                - datetime.timedelta(seconds=float(self.refresh_period_charging))
-            )
+            result = self.last_successful_refresh < datetime.datetime.now(
+                tz=datetime.UTC
+            ) - datetime.timedelta(seconds=float(self.refresh_period_charging))
             LOG.debug(f"HV battery is charging. Should refresh: {result}")
             self.__publish_polling_phase(PollingPhase.CHARGING)
             return result
         if self.hv_battery_active:
-            result = (
-                self.last_successful_refresh
-                < datetime.datetime.now(tz=datetime.UTC)
-                - datetime.timedelta(seconds=float(self.refresh_period_active))
-            )
+            result = self.last_successful_refresh < datetime.datetime.now(
+                tz=datetime.UTC
+            ) - datetime.timedelta(seconds=float(self.refresh_period_active))
             LOG.debug(f"HV battery is active. Should refresh: {result}")
             self.__publish_polling_phase(PollingPhase.ACTIVE)
             return result
@@ -447,21 +457,17 @@ class VehicleState:
             seconds=float(self.refresh_period_inactive_grace)
         )
         if last_shutdown_plus_refresh > datetime.datetime.now(tz=datetime.UTC):
-            result = (
-                self.last_successful_refresh
-                < datetime.datetime.now(tz=datetime.UTC)
-                - datetime.timedelta(seconds=float(self.refresh_period_after_shutdown))
-            )
+            result = self.last_successful_refresh < datetime.datetime.now(
+                tz=datetime.UTC
+            ) - datetime.timedelta(seconds=float(self.refresh_period_after_shutdown))
             LOG.debug(
                 f"Refresh grace period after shutdown has not passed. Should refresh: {result}"
             )
             self.__publish_polling_phase(PollingPhase.AFTER_SHUTDOWN)
             return result
-        result = (
-            self.last_successful_refresh
-            < datetime.datetime.now(tz=datetime.UTC)
-            - datetime.timedelta(seconds=float(self.refresh_period_inactive))
-        )
+        result = self.last_successful_refresh < datetime.datetime.now(
+            tz=datetime.UTC
+        ) - datetime.timedelta(seconds=float(self.refresh_period_inactive))
         LOG.debug(
             f"HV battery is inactive and refresh period after shutdown is over. Should refresh: {result}"
         )

--- a/tests/handlers/test_vehicle_command.py
+++ b/tests/handlers/test_vehicle_command.py
@@ -336,18 +336,23 @@ class TestRetainedReplay(unittest.IsolatedAsyncioTestCase):
         vehicle_state.update_battery_capacity.assert_called_once_with(50.0)
         pub.publish_str.assert_any_call(TOTAL_BATTERY_CAPACITY_RESULT_TOPIC, "Success")
 
-    async def test_retained_clear_command_skipped(self) -> None:
-        """A retained replay must not delete its own retained command from the broker.
+    async def test_retained_action_command_dropped_at_dispatcher(self) -> None:
+        """Retained `/set` for an action-bearing command is dropped at the dispatcher.
 
-        DrivetrainChargingCommand returns RESULT_REFRESH_AND_CLEAR. When called
-        with retained=True the dispatcher must skip the clear_topic call so the
-        retained intent remains on the broker for the next restart.
+        DrivetrainChargingCommand has not opted in via
+        is_replayable_when_retained(). A retained replay of `charging/set` (e.g.
+        from a non-HA client that mistakenly retained the topic) must NOT
+        invoke the handler — otherwise the SAIC charging API call would re-fire
+        on every gateway restart.
         """
-        handler, pub = _build()
+        saic_api = AsyncMock()
+        handler, pub = _build(saic_api=saic_api)
 
         await handler.handle_mqtt_command(
             topic=CHARGING_SET_TOPIC, payload="true", retained=True
         )
 
+        # Handler never ran: no API call, no Success/result publish, no clear_topic
+        saic_api.control_charging.assert_not_called()
+        pub.publish_str.assert_not_called()
         pub.clear_topic.assert_not_called()
-        pub.publish_str.assert_any_call(CHARGING_RESULT_TOPIC, "Success")

--- a/tests/handlers/test_vehicle_command.py
+++ b/tests/handlers/test_vehicle_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,11 +8,14 @@ from saic_ismart_client_ng.exceptions import SaicApiException, SaicLogoutExcepti
 
 from handlers.vehicle_command import VehicleCommandHandler
 import mqtt_topics
+from vehicle import RefreshMode
 
 MQTT_TOPIC = "saic"
 VIN = "vin_test_000000000"
 VEHICLE_PREFIX = f"vehicles/{VIN}"
-CHARGING_SET_TOPIC = f"{MQTT_TOPIC}/{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_CHARGING_SET}"
+CHARGING_SET_TOPIC = (
+    f"{MQTT_TOPIC}/{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_CHARGING_SET}"
+)
 CHARGING_RESULT_TOPIC = (
     f"{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_CHARGING}/{mqtt_topics.RESULT_SUFFIX}"
 )
@@ -182,9 +186,7 @@ class TestSaicLogoutException(unittest.IsolatedAsyncioTestCase):
 
         await handler.handle_mqtt_command(topic=CHARGING_SET_TOPIC, payload="true")
 
-        pub.publish_str.assert_any_call(
-            CHARGING_RESULT_TOPIC, "Failed: retry boom"
-        )
+        pub.publish_str.assert_any_call(CHARGING_RESULT_TOPIC, "Failed: retry boom")
         pub.publish_json.assert_called_once()
         event = pub.publish_json.call_args[0][1]
         assert event["detail"] == "retry boom"
@@ -239,3 +241,113 @@ class TestErrorEventPayload(unittest.IsolatedAsyncioTestCase):
         assert event["event_type"] == "command_error"
         assert event["command"] == mqtt_topics.DRIVETRAIN_CHARGING_SET
         assert "operation too frequent" in event["detail"]
+
+
+REFRESH_MODE_SET_TOPIC = f"{MQTT_TOPIC}/{VEHICLE_PREFIX}/{mqtt_topics.REFRESH_MODE_SET}"
+REFRESH_MODE_RESULT_TOPIC = (
+    f"{VEHICLE_PREFIX}/{mqtt_topics.REFRESH_MODE}/{mqtt_topics.RESULT_SUFFIX}"
+)
+TOTAL_BATTERY_CAPACITY_SET_TOPIC = (
+    f"{MQTT_TOPIC}/{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY_SET}"
+)
+TOTAL_BATTERY_CAPACITY_RESULT_TOPIC = (
+    f"{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY}"
+    f"/{mqtt_topics.RESULT_SUFFIX}"
+)
+
+
+class TestRetainedReplay(unittest.IsolatedAsyncioTestCase):
+    """Behavior for retained `/set` commands replayed on broker reconnect.
+
+    Idempotent values (refresh periods, OFF/PERIODIC mode, battery capacity)
+    must seed in-memory state. One-shot refresh modes (FORCE /
+    CHARGING_DETECTION) must be dropped to avoid looping a poll on every
+    gateway restart.
+    """
+
+    async def test_retained_force_refresh_mode_dropped(self) -> None:
+        handler, pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=REFRESH_MODE_SET_TOPIC, payload="force", retained=True
+        )
+
+        vehicle_state.set_refresh_mode.assert_not_called()
+        pub.publish_str.assert_any_call(REFRESH_MODE_RESULT_TOPIC, "Success")
+
+    async def test_retained_charging_detection_refresh_mode_dropped(self) -> None:
+        handler, pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=REFRESH_MODE_SET_TOPIC,
+            payload="charging_detection",
+            retained=True,
+        )
+
+        vehicle_state.set_refresh_mode.assert_not_called()
+        pub.publish_str.assert_any_call(REFRESH_MODE_RESULT_TOPIC, "Success")
+
+    async def test_retained_periodic_refresh_mode_applied(self) -> None:
+        handler, _pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=REFRESH_MODE_SET_TOPIC, payload="periodic", retained=True
+        )
+
+        vehicle_state.set_refresh_mode.assert_called_once()
+        mode_arg = vehicle_state.set_refresh_mode.call_args[0][0]
+        assert mode_arg is RefreshMode.PERIODIC
+
+    async def test_retained_off_refresh_mode_applied(self) -> None:
+        handler, _pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=REFRESH_MODE_SET_TOPIC, payload="off", retained=True
+        )
+
+        vehicle_state.set_refresh_mode.assert_called_once()
+        mode_arg = vehicle_state.set_refresh_mode.call_args[0][0]
+        assert mode_arg is RefreshMode.OFF
+
+    async def test_non_retained_force_still_applied(self) -> None:
+        handler, _pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=REFRESH_MODE_SET_TOPIC, payload="force", retained=False
+        )
+
+        vehicle_state.set_refresh_mode.assert_called_once()
+        mode_arg = vehicle_state.set_refresh_mode.call_args[0][0]
+        assert mode_arg is RefreshMode.FORCE
+
+    async def test_retained_battery_capacity_replays_to_vehicle_info(self) -> None:
+        handler, pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+
+        await handler.handle_mqtt_command(
+            topic=TOTAL_BATTERY_CAPACITY_SET_TOPIC, payload="50.0", retained=True
+        )
+
+        vehicle_state.update_battery_capacity.assert_called_once_with(50.0)
+        pub.publish_str.assert_any_call(TOTAL_BATTERY_CAPACITY_RESULT_TOPIC, "Success")
+
+    async def test_retained_clear_command_skipped(self) -> None:
+        """A retained replay must not delete its own retained command from the broker.
+
+        DrivetrainChargingCommand returns RESULT_REFRESH_AND_CLEAR. When called
+        with retained=True the dispatcher must skip the clear_topic call so the
+        retained intent remains on the broker for the next restart.
+        """
+        handler, pub = _build()
+
+        await handler.handle_mqtt_command(
+            topic=CHARGING_SET_TOPIC, payload="true", retained=True
+        )
+
+        pub.clear_topic.assert_not_called()
+        pub.publish_str.assert_any_call(CHARGING_RESULT_TOPIC, "Success")

--- a/tests/integrations/home_assistant/test_discovery_retain.py
+++ b/tests/integrations/home_assistant/test_discovery_retain.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from saic_ismart_client_ng.api.vehicle.schema import (
+    VehicleModelConfiguration,
+    VinInfo,
+)
+
+from configuration import Configuration
+from integrations.home_assistant.discovery import HomeAssistantDiscovery
+import mqtt_topics
+from tests.common_mocks import VIN
+from tests.mocks import MessageCapturingConsolePublisher
+from vehicle import RefreshMode, VehicleState
+from vehicle_info import VehicleInfo
+
+# Six entities whose `/set` commands HA must retain so the user's last value
+# survives a gateway restart. Stored as the path suffix of the entity's state
+# topic so we can match against published HA discovery payloads.
+RETAINED_ENTITY_TOPICS = {
+    mqtt_topics.REFRESH_MODE,
+    mqtt_topics.REFRESH_PERIOD_ACTIVE,
+    mqtt_topics.REFRESH_PERIOD_INACTIVE,
+    mqtt_topics.REFRESH_PERIOD_AFTER_SHUTDOWN,
+    mqtt_topics.REFRESH_PERIOD_INACTIVE_GRACE,
+    mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY,
+}
+
+# Sample of writable entities that must NOT be retained. SOC target / charge
+# current are API-backed; charging is action-bearing.
+NON_RETAINED_ENTITY_TOPICS = {
+    mqtt_topics.DRIVETRAIN_SOC_TARGET,
+    mqtt_topics.DRIVETRAIN_CHARGECURRENT_LIMIT,
+}
+
+
+def _make_discovery() -> tuple[
+    HomeAssistantDiscovery, MessageCapturingConsolePublisher
+]:
+    config = Configuration()
+    config.anonymized_publishing = False
+    config.ha_discovery_prefix = "homeassistant"
+    publisher = MessageCapturingConsolePublisher(config)
+    vin_info = VinInfo()
+    vin_info.vin = VIN
+    vin_info.series = "EH32 S"
+    vin_info.modelName = "MG4 Electric"
+    vin_info.modelYear = "2022"
+    vin_info.vehicleModelConfiguration = [
+        VehicleModelConfiguration("BATTERY", "BATTERY", "1"),
+        VehicleModelConfiguration("BType", "Battery", "1"),
+    ]
+    vehicle_info = VehicleInfo(vin_info, None)
+    account_prefix = f"/vehicles/{VIN}"
+    scheduler = BlockingScheduler()
+    vehicle_state = VehicleState(publisher, scheduler, account_prefix, vehicle_info)
+    vehicle_state.refresh_period_active = 30
+    vehicle_state.refresh_period_inactive = 120
+    vehicle_state.refresh_period_after_shutdown = 60
+    vehicle_state.refresh_period_inactive_grace = 600
+    vehicle_state.refresh_mode = RefreshMode.PERIODIC
+    discovery = HomeAssistantDiscovery(vehicle_state, vehicle_info, config)
+    return discovery, publisher
+
+
+def _writable_payloads(
+    publisher: MessageCapturingConsolePublisher,
+) -> list[dict[str, object]]:
+    """Return every published discovery payload that has a `command_topic`."""
+    payloads: list[dict[str, object]] = []
+    for raw in publisher.map.values():
+        try:
+            payload = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict) and "command_topic" in payload:
+            payloads.append(payload)
+    return payloads
+
+
+def _payload_for_state_topic_suffix(
+    payloads: list[dict[str, object]], suffix: str
+) -> dict[str, object] | None:
+    for payload in payloads:
+        state_topic = payload.get("state_topic")
+        if isinstance(state_topic, str) and state_topic.endswith(f"/{suffix}"):
+            return payload
+    return None
+
+
+class TestDiscoveryRetainFlag(unittest.TestCase):
+    """The six idempotent persistence-relevant entities must be retained."""
+
+    def test_required_entities_have_retain_true(self) -> None:
+        discovery, publisher = _make_discovery()
+        discovery.publish_ha_discovery_messages()
+        payloads = _writable_payloads(publisher)
+
+        for topic in RETAINED_ENTITY_TOPICS:
+            payload = _payload_for_state_topic_suffix(payloads, topic)
+            assert payload is not None, (
+                f"No writable HA discovery payload found for topic {topic}"
+            )
+            assert payload.get("retain") == "true", (
+                f"Expected retain=true for {topic}, got {payload.get('retain')!r}"
+            )
+
+    def test_non_retained_entities_keep_retain_false(self) -> None:
+        discovery, publisher = _make_discovery()
+        discovery.publish_ha_discovery_messages()
+        payloads = _writable_payloads(publisher)
+
+        for topic in NON_RETAINED_ENTITY_TOPICS:
+            payload = _payload_for_state_topic_suffix(payloads, topic)
+            if payload is None:
+                continue  # entity not published for this vehicle config
+            assert payload.get("retain") in ("false", None), (
+                f"Expected retain!=true for {topic}, got {payload.get('retain')!r}"
+            )

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -24,10 +24,11 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
 
     @override
     async def on_mqtt_command_received(
-        self, *, vin: str, topic: str, payload: str
+        self, *, vin: str, topic: str, payload: str, retained: bool = False
     ) -> None:
         self.received_vin = vin
         self.received_payload = payload.strip().lower()
+        self.received_retained = retained
 
     @override
     def setUp(self) -> None:
@@ -39,6 +40,7 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
         self.mqtt_client.command_listener = self
         self.received_vin = ""
         self.received_payload = ""
+        self.received_retained = False
         self.vehicle_base_topic = (
             f"{self.mqtt_client.configuration.mqtt_topic}/{USER}/vehicles/{VIN}"
         )

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -192,9 +192,9 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
             self.get_topic(mqtt_topics.CLIMATE_REMOTE_TEMPERATURE)
             not in self.publisher.map
         )
-        # refresh_mode defaults to RefreshMode.OFF (never None), so it IS always published
+        # refresh_mode defaults to RefreshMode.PERIODIC (never None), so it IS always published
         self.assert_mqtt_topic(
-            self.get_topic(mqtt_topics.REFRESH_MODE), RefreshMode.OFF.value
+            self.get_topic(mqtt_topics.REFRESH_MODE), RefreshMode.PERIODIC.value
         )
 
     def test_configure_missing_skips_when_retained_value_present(self) -> None:
@@ -218,6 +218,11 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         assert self.vehicle_state.refresh_period_inactive == 86400
         assert self.vehicle_state.refresh_period_after_shutdown == 120
         assert self.vehicle_state.refresh_period_inactive_grace == 600
+
+    def test_configure_missing_preserves_retained_off_refresh_mode(self) -> None:
+        self.vehicle_state.set_refresh_mode(RefreshMode.OFF, "retained replay")
+        self.vehicle_state.configure_missing()
+        assert self.vehicle_state.refresh_mode == RefreshMode.OFF
 
     def test_republish_command_states_includes_api_values(self) -> None:
         self.vehicle_state.configure_missing()

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -197,6 +197,28 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
             self.get_topic(mqtt_topics.REFRESH_MODE), RefreshMode.OFF.value
         )
 
+    def test_configure_missing_skips_when_retained_value_present(self) -> None:
+        """Sentinel guards in configure_missing preserve retained-replay values.
+
+        Retained `/set` replay seeds in-memory state before configure_missing
+        runs; configure_missing must then leave those values alone.
+        """
+        self.vehicle_state.set_refresh_period_active(45)
+        self.vehicle_state.update_battery_capacity(50.0)
+
+        self.vehicle_state.configure_missing()
+
+        assert self.vehicle_state.refresh_period_active == 45
+        assert self.vehicle_state.vehicle.custom_battery_capacity == 50.0
+
+    def test_configure_missing_applies_defaults_when_no_retained(self) -> None:
+        assert self.vehicle_state.refresh_period_active == -1
+        self.vehicle_state.configure_missing()
+        assert self.vehicle_state.refresh_period_active == 30
+        assert self.vehicle_state.refresh_period_inactive == 86400
+        assert self.vehicle_state.refresh_period_after_shutdown == 120
+        assert self.vehicle_state.refresh_period_inactive_grace == 600
+
     def test_republish_command_states_includes_api_values(self) -> None:
         self.vehicle_state.configure_missing()
         self.vehicle_state.update_target_soc(TargetBatteryCode.P_80)
@@ -280,7 +302,9 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
     def test_handle_vehicle_status_rejects_drifted_timestamp(self) -> None:
         resp = get_mock_vehicle_status_resp()
         resp.statusTime = 1000000000  # 2001-09-09, well outside 15 min window
-        with pytest.raises(VehicleStatusDriftException, match="drifted more than 15 minutes"):
+        with pytest.raises(
+            VehicleStatusDriftException, match="drifted more than 15 minutes"
+        ):
             self.vehicle_state.handle_vehicle_status(resp)
 
     def test_mileage_of_day_published_when_valid(self) -> None:
@@ -303,7 +327,9 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
         # Set mileageOfDay raw value higher than total mileage raw value
         assert chrg_mgmt_data_resp.rvsChargeStatus is not None
-        chrg_mgmt_data_resp.rvsChargeStatus.mileageOfDay = (DRIVETRAIN_MILEAGE + 100) * 10
+        chrg_mgmt_data_resp.rvsChargeStatus.mileageOfDay = (
+            DRIVETRAIN_MILEAGE + 100
+        ) * 10
         self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
 
         assert (
@@ -318,7 +344,9 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
 
         chrg_mgmt_data_resp = get_mock_charge_management_data_resp()
         assert chrg_mgmt_data_resp.rvsChargeStatus is not None
-        chrg_mgmt_data_resp.rvsChargeStatus.mileageSinceLastCharge = (DRIVETRAIN_MILEAGE + 100) * 10
+        chrg_mgmt_data_resp.rvsChargeStatus.mileageSinceLastCharge = (
+            DRIVETRAIN_MILEAGE + 100
+        ) * 10
         self.vehicle_state.handle_charge_status(chrg_mgmt_data_resp)
 
         assert (
@@ -442,9 +470,7 @@ class TestVehicleState(unittest.IsolatedAsyncioTestCase):
         self.vehicle_state.configure_missing()
         # Car just shut down, grace period active
         self.vehicle_state.hv_battery_active = False
-        self.vehicle_state.last_car_shutdown = datetime.datetime.now(
-            tz=datetime.UTC
-        )
+        self.vehicle_state.last_car_shutdown = datetime.datetime.now(tz=datetime.UTC)
         self.vehicle_state.last_car_activity = datetime.datetime.min.replace(
             tzinfo=datetime.UTC
         )


### PR DESCRIPTION
## Summary

- Adds `retain: true` to the HA discovery payloads of the six writable entities whose values are user-set and should survive a gateway restart: the four `refresh_period_*` numbers, `refresh_mode`, and `totalBatteryCapacity`. HA now publishes their `/set` commands with `retain=true`, so the broker keeps the user's last intent.
- On reconnect, the existing `/set` subscription delivers the retained command, the existing dispatch path runs unchanged, and `configure_missing()`'s already-correct sentinel guards (`-1` / `None`) make the config defaults no-op.
- Plumbs the gmqtt `retain` flag from `__on_message` through the command path so `RefreshModeCommand` can drop a retained one-shot mode (`force` / `charging_detection`) — otherwise a single-shot poll would loop on every restart. `OFF` and `PERIODIC` replay normally.
- Suppresses `clear_command` (`publisher.clear_topic`) on retained replays so the dispatcher does not erase the user's intent from the broker.
- API-backed values (SOC target, charge current limit, charging schedule, battery heating schedule) remain `retain=false` — the SAIC API is the source of truth on first read.

**Unblocks #440** (`fix/ha-number-optimistic-state`): once persistence works, the paused PR can rebase and ship `optimistic: false` without regressing user settings.

**First-deploy caveat** (in CHANGELOG): existing retained STATE topics on the broker are not retained `/set` commands, so persistence kicks in only after the user next changes a setting from HA.

## Test plan

- [x] `pytest` — all 179 tests pass (10 new).
- [x] `pre-commit run --all-files` — ruff + ruff-format + mypy clean.
- [x] New tests cover: retained FORCE / CHARGING_DETECTION dropped; retained PERIODIC / OFF applied; non-retained FORCE still applied (regression); retained battery capacity replays to `vehicle.custom_battery_capacity`; retained `clear_command` skipped; `configure_missing` preserves seeded retained values; the six entities have `retain=true` in HA discovery while sample non-retained entities do not.
- [ ] Manual: with the gateway running in k8s, change a refresh period from HA, restart the pod, confirm value persists. Set `refresh_mode = force` from HA, observe one poll, restart pod, confirm FORCE does NOT replay (log: "Dropping retained one-shot refresh mode force").