### PR TITLE
fix: forward retain flag through all typed publish methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         language: system
         types:
           - python
+        pass_filenames: false
         require_serial: true
       - id: pytest
         name: Run pytest

--- a/src/publisher/core.py
+++ b/src/publisher/core.py
@@ -85,19 +85,27 @@ class Publisher(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def publish_str(self, key: str, value: str, no_prefix: bool = False) -> None:
+    def publish_str(
+        self, key: str, value: str, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def publish_int(self, key: str, value: int, no_prefix: bool = False) -> None:
+    def publish_int(
+        self, key: str, value: int, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def publish_bool(self, key: str, value: bool, no_prefix: bool = False) -> None:
+    def publish_bool(
+        self, key: str, value: bool, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def publish_float(self, key: str, value: float, no_prefix: bool = False) -> None:
+    def publish_float(
+        self, key: str, value: float, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/publisher/log_publisher.py
+++ b/src/publisher/log_publisher.py
@@ -31,41 +31,36 @@ class ConsolePublisher(Publisher):
         *,
         retain: bool = True,
     ) -> None:
-        del retain  # console output has no retention semantics
         anonymized_json = self.dict_to_anonymized_json(data)
-        self.internal_publish(key, anonymized_json)
+        self.internal_publish(key, anonymized_json, retain=retain)
 
     @override
     def publish_str(
         self, key: str, value: str, no_prefix: bool = False, *, retain: bool = True
     ) -> None:
-        del retain
-        self.internal_publish(key, value)
+        self.internal_publish(key, value, retain=retain)
 
     @override
     def publish_int(
         self, key: str, value: int, no_prefix: bool = False, *, retain: bool = True
     ) -> None:
-        del retain
-        self.internal_publish(key, value)
+        self.internal_publish(key, value, retain=retain)
 
     @override
     def publish_bool(
         self, key: str, value: bool, no_prefix: bool = False, *, retain: bool = True
     ) -> None:
-        del retain
-        self.internal_publish(key, value)
+        self.internal_publish(key, value, retain=retain)
 
     @override
     def publish_float(
         self, key: str, value: float, no_prefix: bool = False, *, retain: bool = True
     ) -> None:
-        del retain
-        self.internal_publish(key, value)
+        self.internal_publish(key, value, retain=retain)
 
     @override
     def clear_topic(self, key: str, no_prefix: bool = False) -> None:
         self.internal_publish(key, None)
 
-    def internal_publish(self, key: str, value: Any) -> None:
-        LOG.debug(f"{key}: {value}")
+    def internal_publish(self, key: str, value: Any, *, retain: bool = True) -> None:
+        LOG.debug(f"{key}: {value} (retain={retain})")

--- a/src/publisher/log_publisher.py
+++ b/src/publisher/log_publisher.py
@@ -31,23 +31,36 @@ class ConsolePublisher(Publisher):
         *,
         retain: bool = True,
     ) -> None:
+        del retain  # console output has no retention semantics
         anonymized_json = self.dict_to_anonymized_json(data)
         self.internal_publish(key, anonymized_json)
 
     @override
-    def publish_str(self, key: str, value: str, no_prefix: bool = False) -> None:
+    def publish_str(
+        self, key: str, value: str, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        del retain
         self.internal_publish(key, value)
 
     @override
-    def publish_int(self, key: str, value: int, no_prefix: bool = False) -> None:
+    def publish_int(
+        self, key: str, value: int, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        del retain
         self.internal_publish(key, value)
 
     @override
-    def publish_bool(self, key: str, value: bool, no_prefix: bool = False) -> None:
+    def publish_bool(
+        self, key: str, value: bool, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        del retain
         self.internal_publish(key, value)
 
     @override
-    def publish_float(self, key: str, value: float, no_prefix: bool = False) -> None:
+    def publish_float(
+        self, key: str, value: float, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        del retain
         self.internal_publish(key, value)
 
     @override

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -248,20 +248,36 @@ class MqttPublisher(Publisher):
         )
 
     @override
-    def publish_str(self, key: str, value: str, no_prefix: bool = False) -> None:
-        self.__publish(topic=self.get_topic(key, no_prefix), payload=value)
+    def publish_str(
+        self, key: str, value: str, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        self.__publish(
+            topic=self.get_topic(key, no_prefix), payload=value, retain=retain
+        )
 
     @override
-    def publish_int(self, key: str, value: int, no_prefix: bool = False) -> None:
-        self.__publish(topic=self.get_topic(key, no_prefix), payload=value)
+    def publish_int(
+        self, key: str, value: int, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        self.__publish(
+            topic=self.get_topic(key, no_prefix), payload=value, retain=retain
+        )
 
     @override
-    def publish_bool(self, key: str, value: bool, no_prefix: bool = False) -> None:
-        self.__publish(topic=self.get_topic(key, no_prefix), payload=value)
+    def publish_bool(
+        self, key: str, value: bool, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        self.__publish(
+            topic=self.get_topic(key, no_prefix), payload=value, retain=retain
+        )
 
     @override
-    def publish_float(self, key: str, value: float, no_prefix: bool = False) -> None:
-        self.__publish(topic=self.get_topic(key, no_prefix), payload=value)
+    def publish_float(
+        self, key: str, value: float, no_prefix: bool = False, *, retain: bool = True
+    ) -> None:
+        self.__publish(
+            topic=self.get_topic(key, no_prefix), payload=value, retain=retain
+        )
 
     @override
     def clear_topic(self, key: str, no_prefix: bool = False) -> None:

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -18,7 +18,7 @@ class MessageCapturingConsolePublisher(ConsolePublisher):
         self.publish_count: dict[str, int] = {}
 
     @override
-    def internal_publish(self, key: str, value: Any) -> None:
+    def internal_publish(self, key: str, value: Any, *, retain: bool = True) -> None:
         self.map[key] = value
         self.publish_count[key] = self.publish_count.get(key, 0) + 1
-        LOG.debug(f"{key}: {value}")
+        LOG.debug(f"{key}: {value} (retain={retain})")

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -110,17 +110,53 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
             self.mqtt_client.publish_str("foo", "bar", retain=False)
             m_pub.assert_called_once_with("saic/foo", "bar", retain=False)
 
+    def test_publish_int_default_is_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_int("foo", 42)
+            m_pub.assert_called_once_with("saic/foo", 42, retain=True)
+
     def test_publish_int_forwards_retain_false(self) -> None:
         with patch.object(self.mqtt_client.client, "publish") as m_pub:
             self.mqtt_client.publish_int("foo", 42, retain=False)
             m_pub.assert_called_once_with("saic/foo", 42, retain=False)
+
+    def test_publish_bool_default_is_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_bool("foo", True)
+            m_pub.assert_called_once_with("saic/foo", True, retain=True)
 
     def test_publish_bool_forwards_retain_false(self) -> None:
         with patch.object(self.mqtt_client.client, "publish") as m_pub:
             self.mqtt_client.publish_bool("foo", True, retain=False)
             m_pub.assert_called_once_with("saic/foo", True, retain=False)
 
+    def test_publish_float_default_is_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_float("foo", 1.5)
+            m_pub.assert_called_once_with("saic/foo", 1.5, retain=True)
+
     def test_publish_float_forwards_retain_false(self) -> None:
         with patch.object(self.mqtt_client.client, "publish") as m_pub:
             self.mqtt_client.publish_float("foo", 1.5, retain=False)
             m_pub.assert_called_once_with("saic/foo", 1.5, retain=False)
+
+    def test_publish_json_default_is_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_json("foo", {"a": 1})
+            m_pub.assert_called_once()
+            args, kwargs = m_pub.call_args
+            assert args[0] == "saic/foo"
+            assert kwargs == {"retain": True}
+
+    def test_publish_json_forwards_retain_false(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_json("foo", {"a": 1}, retain=False)
+            m_pub.assert_called_once()
+            args, kwargs = m_pub.call_args
+            assert args[0] == "saic/foo"
+            assert kwargs == {"retain": False}
+
+    def test_clear_topic_publishes_none_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.clear_topic("foo")
+            m_pub.assert_called_once_with("saic/foo", None, retain=True)

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, override
 import unittest
+from unittest.mock import patch
 
 from configuration import Configuration, TransportProtocol
 from publisher.core import MqttCommandListener
@@ -98,3 +99,28 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
         self, vin: str, connected: bool
     ) -> None:
         pass
+
+    def test_publish_str_default_is_retained(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_str("foo", "bar")
+            m_pub.assert_called_once_with("saic/foo", "bar", retain=True)
+
+    def test_publish_str_forwards_retain_false(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_str("foo", "bar", retain=False)
+            m_pub.assert_called_once_with("saic/foo", "bar", retain=False)
+
+    def test_publish_int_forwards_retain_false(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_int("foo", 42, retain=False)
+            m_pub.assert_called_once_with("saic/foo", 42, retain=False)
+
+    def test_publish_bool_forwards_retain_false(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_bool("foo", True, retain=False)
+            m_pub.assert_called_once_with("saic/foo", True, retain=False)
+
+    def test_publish_float_forwards_retain_false(self) -> None:
+        with patch.object(self.mqtt_client.client, "publish") as m_pub:
+            self.mqtt_client.publish_float("foo", 1.5, retain=False)
+            m_pub.assert_called_once_with("saic/foo", 1.5, retain=False)


### PR DESCRIPTION
## Summary

The MQTT broker accepts `retain` on every PUBLISH frame, but the typed publisher API only honored it for `publish_json`. Calls to `publish_str/int/bool/float` silently retained regardless of caller intent — there was no way to opt out for non-JSON payloads.

This PR adds `retain: bool = True` (kwarg-only) to every typed publish method on the `Publisher` ABC and forwards it through `MqttPublisher` to the gmqtt client. `ConsolePublisher` accepts and ignores it (no retention semantics for log output).

API-additive: existing call sites continue to work unchanged since `retain` defaults to `True`.

Surfaced while reviewing #442, where the dispatcher's `Publisher.publish(retain=...)` only forwarded `retain` to the `dict` arm. Splitting this fix out so it can land independently and #442 can rebase on a develop where retain is already first-class.

## Test plan

- [x] New tests cover `publish_str/int/bool/float` retain forwarding (default + `retain=False`) on `MqttPublisher` via patched `client.publish`.
- [x] Existing test suite passes (185 tests).
- [x] mypy clean across the project.