### PR TITLE
fix: republish Total Battery Capacity after HA number update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
   persistent. Existing retained STATE values on the broker are not converted
   into retained `/set` commands.
 
+* Republish the effective Total Battery Capacity to its state topic right after
+  the user updates the HA number. The `_set` handler used to only mutate the
+  in-memory override and rely on the next vehicle poll to refresh the shared
+  sensor topic, leaving the HA sensor stuck on the previous (often hardcoded
+  per-model default) value while the number widget already showed the new
+  setting. A payload of `0` re-publishes the per-model default via
+  `real_battery_capacity`.
+
 ## 0.11.0
 
 ### Added

--- a/src/handlers/command/drivetrain/drivetrain_total_battery_capacity.py
+++ b/src/handlers/command/drivetrain/drivetrain_total_battery_capacity.py
@@ -29,5 +29,18 @@ class DrivetrainTotalBatteryCapacitySetCommand(FloatCommandHandler):
         LOG.info("Setting Total Battery Capacity to %f", payload)
         self.vehicle_state.update_battery_capacity(payload)
 
+        # The HA number and sensor entities share the same state topic.
+        # Republish the effective capacity locally so the sensor reflects
+        # the change immediately instead of waiting for the next vehicle poll
+        # (payload of 0 falls back to the per-model default in real_battery_capacity).
+        effective_capacity = self.vehicle_state.vehicle.real_battery_capacity
+        if effective_capacity is not None and effective_capacity > 0:
+            self.publisher.publish_float(
+                self.vehicle_state.get_topic(
+                    mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY
+                ),
+                effective_capacity,
+            )
+
         # No need to force a refresh
         return RESULT_DO_NOTHING

--- a/tests/handlers/test_vehicle_command.py
+++ b/tests/handlers/test_vehicle_command.py
@@ -254,6 +254,9 @@ TOTAL_BATTERY_CAPACITY_RESULT_TOPIC = (
     f"{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY}"
     f"/{mqtt_topics.RESULT_SUFFIX}"
 )
+TOTAL_BATTERY_CAPACITY_STATE_TOPIC = (
+    f"{VEHICLE_PREFIX}/{mqtt_topics.DRIVETRAIN_TOTAL_BATTERY_CAPACITY}"
+)
 
 
 class TestRetainedReplay(unittest.IsolatedAsyncioTestCase):
@@ -328,13 +331,43 @@ class TestRetainedReplay(unittest.IsolatedAsyncioTestCase):
     async def test_retained_battery_capacity_replays_to_vehicle_info(self) -> None:
         handler, pub = _build()
         vehicle_state = cast("MagicMock", handler.vehicle_state)
+        vehicle_state.vehicle.real_battery_capacity = 50.0
 
         await handler.handle_mqtt_command(
             topic=TOTAL_BATTERY_CAPACITY_SET_TOPIC, payload="50.0", retained=True
         )
 
         vehicle_state.update_battery_capacity.assert_called_once_with(50.0)
+        pub.publish_float.assert_any_call(TOTAL_BATTERY_CAPACITY_STATE_TOPIC, 50.0)
         pub.publish_str.assert_any_call(TOTAL_BATTERY_CAPACITY_RESULT_TOPIC, "Success")
+
+    async def test_battery_capacity_zero_payload_publishes_model_default(self) -> None:
+        """Payload `0` clears the override; the per-model default is republished."""
+        handler, pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+        # update_battery_capacity(0) clears the override; real_battery_capacity then
+        # falls back to the per-model default (e.g. 64 kWh for an MG4 NMC).
+        vehicle_state.vehicle.real_battery_capacity = 64.0
+
+        await handler.handle_mqtt_command(
+            topic=TOTAL_BATTERY_CAPACITY_SET_TOPIC, payload="0", retained=False
+        )
+
+        vehicle_state.update_battery_capacity.assert_called_once_with(0.0)
+        pub.publish_float.assert_any_call(TOTAL_BATTERY_CAPACITY_STATE_TOPIC, 64.0)
+
+    async def test_battery_capacity_skips_publish_when_no_default(self) -> None:
+        """When `real_battery_capacity` returns None (unknown model), skip the publish."""
+        handler, pub = _build()
+        vehicle_state = cast("MagicMock", handler.vehicle_state)
+        vehicle_state.vehicle.real_battery_capacity = None
+
+        await handler.handle_mqtt_command(
+            topic=TOTAL_BATTERY_CAPACITY_SET_TOPIC, payload="0", retained=False
+        )
+
+        vehicle_state.update_battery_capacity.assert_called_once_with(0.0)
+        pub.publish_float.assert_not_called()
 
     async def test_retained_action_command_dropped_at_dispatcher(self) -> None:
         """Retained `/set` for an action-bearing command is dropped at the dispatcher.


### PR DESCRIPTION
## Summary

* The HA "Total Battery Capacity" number and sensor share the same MQTT state topic. Setting the number was only mutating `VehicleInfo.custom_battery_capacity` and returning `RESULT_DO_NOTHING`, so the sensor stayed pinned to the previously published value (typically the per-model default in `rvs_charge_status.get_actual_battery_capacity`) until the next charge-status poll. Result in HA: number widget shows the new value, sensor still shows the old one.
* The handler now republishes `vehicle.real_battery_capacity` to the state topic right after the in-memory update, so the sensor catches up immediately. Reading through `real_battery_capacity` keeps the `payload == 0` (clear override) path consistent — it falls back to the per-model default instead of publishing `0`.
* The kWh-derived sensors (`SoC_kWh`, `Last Charge SoC kWh`, the two `Power Usage` sensors) still use the previous `battery_capacity_correction_factor` until the next charge-status update — same staleness window as before, intentional for this local-only fix.

## Test plan

- [x] Updated `test_retained_battery_capacity_replays_to_vehicle_info` to stub `vehicle.real_battery_capacity` and assert the new state-topic publish.
- [x] Added `test_battery_capacity_zero_payload_publishes_model_default` (payload `0` → per-model default republished).
- [x] Added `test_battery_capacity_skips_publish_when_no_default` (`real_battery_capacity is None` → publish skipped).
- [x] `poetry run pytest` — 276 passed.