### PR TITLE
fix(ha): emit retain as JSON boolean in discovery payloads

### DIFF
--- a/src/integrations/home_assistant/base.py
+++ b/src/integrations/home_assistant/base.py
@@ -55,7 +55,7 @@ class HomeAssistantDiscoveryBase(metaclass=abc.ABCMeta):
             "command_topic": self._get_command_topic(topic),
             "value_template": value_template,
             "command_template": command_template,
-            "retain": str(retain).lower(),
+            "retain": retain,
             "options": options,
             "enabled_by_default": enabled,
         }
@@ -87,7 +87,7 @@ class HomeAssistantDiscoveryBase(metaclass=abc.ABCMeta):
             "command_topic": self._get_command_topic(topic),
             "value_template": value_template,
             "command_template": command_template,
-            "retain": str(retain).lower(),
+            "retain": retain,
             "enabled_by_default": enabled,
         }
         if min_value is not None:
@@ -153,7 +153,7 @@ class HomeAssistantDiscoveryBase(metaclass=abc.ABCMeta):
             "state_topic": self._get_state_topic(topic),
             "command_topic": self._get_command_topic(topic),
             "value_template": value_template,
-            "retain": str(retain).lower(),
+            "retain": retain,
             "mode": mode,
             "min": min_value,
             "max": max_value,

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -133,7 +133,9 @@ class MqttPublisher(Publisher):
                     reconnect_interval,
                 )
                 await asyncio.sleep(reconnect_interval)
-                reconnect_interval = min(reconnect_interval * 2, _RECONNECT_INTERVAL_MAX)
+                reconnect_interval = min(
+                    reconnect_interval * 2, _RECONNECT_INTERVAL_MAX
+                )
             except aiomqtt.MqttError:
                 LOG.warning(
                     "Connection to %s:%s lost; Reconnecting in %d seconds ...",
@@ -142,7 +144,9 @@ class MqttPublisher(Publisher):
                     reconnect_interval,
                 )
                 await asyncio.sleep(reconnect_interval)
-                reconnect_interval = min(reconnect_interval * 2, _RECONNECT_INTERVAL_MAX)
+                reconnect_interval = min(
+                    reconnect_interval * 2, _RECONNECT_INTERVAL_MAX
+                )
             except asyncio.exceptions.CancelledError:
                 LOG.debug("MQTT publisher loop cancelled")
                 raise

--- a/tests/integrations/home_assistant/test_discovery_retain.py
+++ b/tests/integrations/home_assistant/test_discovery_retain.py
@@ -104,7 +104,7 @@ class TestDiscoveryRetainFlag(unittest.TestCase):
             assert payload is not None, (
                 f"No writable HA discovery payload found for topic {topic}"
             )
-            assert payload.get("retain") == "true", (
+            assert payload.get("retain") is True, (
                 f"Expected retain=true for {topic}, got {payload.get('retain')!r}"
             )
 
@@ -117,6 +117,6 @@ class TestDiscoveryRetainFlag(unittest.TestCase):
             payload = _payload_for_state_topic_suffix(payloads, topic)
             if payload is None:
                 continue  # entity not published for this vehicle config
-            assert payload.get("retain") in ("false", None), (
+            assert payload.get("retain") in (False, None), (
                 f"Expected retain!=true for {topic}, got {payload.get('retain')!r}"
             )


### PR DESCRIPTION
## Summary

- `str(retain).lower()` in `HaBaseSwitch` / select / number discovery methods produced Python strings `"true"`/`"false"` which `json.dumps` serialized as JSON strings
- Home Assistant's MQTT discovery schema expects a boolean; the string caused schema validation to reject the `retain` flag
- Command topics for `number` and `select` entities (refresh periods, target SoC) were not retained on the broker, so gateway settings were lost after every HA restart
- Fix: pass `retain` directly — it is already a `bool`

## Test plan

- [ ] Existing `test_discovery_retain.py` tests updated to assert `True`/`False` instead of `"true"`/`"false"` — all 293 tests pass
- [ ] Manual: verify HA number/select entities retain their values after broker restart