### PR TITLE
fix(extractors): suppress SoC kWh warning spam for non-EV vehicles

### DIFF
--- a/src/extractors/__init__.py
+++ b/src/extractors/__init__.py
@@ -43,17 +43,17 @@ def extract_soc_kwh(
     charge_status: ChrgMgmtDataRespProcessingResult | None,
     soc: float | None,
 ) -> float | None:
-    if (
-        charge_status is not None
-        and (raw_soc_kwh := charge_status.soc_kwh) is not None
-        and (soc_kwh := __validate_and_convert_soc_kwh(raw_soc_kwh)) is not None
-    ):
+    if charge_status is None:
+        return None
+
+    if (raw_soc_kwh := charge_status.soc_kwh) is not None and (
+        soc_kwh := __validate_and_convert_soc_kwh(raw_soc_kwh)
+    ) is not None:
         LOG.debug("SoC kWh derived from realtimePower")
         return soc_kwh
 
     if (
         soc is not None
-        and charge_status is not None
         and (
             capacity := __validate_and_convert_soc_kwh(
                 charge_status.real_total_battery_capacity


### PR DESCRIPTION
## Summary

- `extract_soc_kwh` now returns `None` silently when `charge_status is None`
- Non-EV vehicles (e.g., ZP22 series) pass `charge_status=None` on every poll, causing a spurious `WARNING: Could not extract a valid SoC kWh` on every cycle
- The WARNING is preserved for EVs where charge status is present but kWh derivation genuinely fails

## Test plan
- [ ] 293 existing tests still pass (`poetry run pytest tests --cov`)
- [ ] `mypy` clean
- [ ] Manual: non-EV vehicle no longer emits SoC kWh WARNING on each poll