### PR TITLE
fix(tls): warn on hostname-check bypass regardless of custom CA cert

### DIFF
--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -70,10 +70,10 @@ class MqttPublisher(Publisher):
                 ssl_context.load_verify_locations(
                     cafile=self.configuration.tls_server_cert_path
                 )
-                if not self.configuration.tls_server_cert_check_hostname:
-                    LOG.warning(
-                        f"Skipping hostname check for TLS connection to {self.host}"
-                    )
+            if not self.configuration.tls_server_cert_check_hostname:
+                LOG.warning(
+                    f"Skipping hostname check for TLS connection to {self.host}"
+                )
 
         client = aiomqtt.Client(
             hostname=self.host,
@@ -85,9 +85,7 @@ class MqttPublisher(Publisher):
             clean_session=True,
             tls_context=ssl_context,
             tls_insecure=bool(
-                ssl_context
-                and self.configuration.tls_server_cert_path
-                and not self.configuration.tls_server_cert_check_hostname
+                ssl_context and not self.configuration.tls_server_cert_check_hostname
             ),
             will=aiomqtt.Will(
                 topic=self.get_topic(mqtt_topics.INTERNAL_LWT, False),

--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -85,7 +85,9 @@ class MqttPublisher(Publisher):
             clean_session=True,
             tls_context=ssl_context,
             tls_insecure=bool(
-                ssl_context and not self.configuration.tls_server_cert_check_hostname
+                ssl_context
+                and self.configuration.tls_server_cert_path
+                and not self.configuration.tls_server_cert_check_hostname
             ),
             will=aiomqtt.Will(
                 topic=self.get_topic(mqtt_topics.INTERNAL_LWT, False),


### PR DESCRIPTION
## Summary

The `Skipping hostname check` warning was only emitted when a custom CA cert path was also configured. Users with self-signed certs (no CA file) or connecting by IP would silence hostname verification without any log message.

- Moved the warning outside the `tls_server_cert_path` block — it now fires whenever `tls_server_cert_check_hostname=False` for any TLS connection
- Dropped the unrelated `tls_server_cert_path` guard that was incorrectly added to `tls_insecure`

## Behaviour

`tls_insecure` is `True` whenever the user sets `check_hostname=False` with TLS, regardless of whether a custom CA cert is provided. The warning is now always emitted in that case.

## Test plan
- [ ] 293 tests passing
- [ ] `mypy` clean