### PR TITLE
fix(mqtt_publisher): pass tls_insecure=None for non-TLS connections

### DIFF
--- a/src/publisher/mqtt_publisher.py
+++ b/src/publisher/mqtt_publisher.py
@@ -84,8 +84,10 @@ class MqttPublisher(Publisher):
             password=self.configuration.mqtt_password or None,
             clean_session=True,
             tls_context=ssl_context,
-            tls_insecure=bool(
-                ssl_context and not self.configuration.tls_server_cert_check_hostname
+            tls_insecure=(
+                True
+                if ssl_context and not self.configuration.tls_server_cert_check_hostname
+                else None
             ),
             will=aiomqtt.Will(
                 topic=self.get_topic(mqtt_topics.INTERNAL_LWT, False),

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 import json
 from typing import Any, override
 import unittest
@@ -171,3 +172,45 @@ class TestMqttPublisher(unittest.IsolatedAsyncioTestCase, MqttCommandListener):
     async def test_clear_topic_publishes_none_retained(self) -> None:
         m = await self._call_and_flush(self.mqtt_client.clear_topic, "foo")
         m.assert_called_once_with("saic/foo", None, retain=True, qos=0)
+
+    async def _connect_and_capture_client_kwargs(
+        self, config: Configuration
+    ) -> dict[str, Any]:
+        publisher = MqttPublisher(config)
+        with patch("publisher.mqtt_publisher.aiomqtt.Client") as client_cls:
+            client_cls.return_value.__aenter__.side_effect = asyncio.CancelledError
+            connect_task = asyncio.get_running_loop().create_task(publisher.connect())
+            for _ in range(20):
+                await asyncio.sleep(0)
+                if client_cls.call_args is not None:
+                    break
+            connect_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await connect_task
+            assert client_cls.call_args is not None
+            return dict(client_cls.call_args.kwargs)
+
+    async def test_plain_tcp_leaves_tls_insecure_unset(self) -> None:
+        """tls_insecure must stay None without TLS, else paho raises ValueError."""
+        config = Configuration()
+        config.mqtt_host = "localhost"
+        config.mqtt_transport_protocol = TransportProtocol.TCP
+        kwargs = await self._connect_and_capture_client_kwargs(config)
+        assert kwargs["tls_insecure"] is None
+        assert kwargs["tls_context"] is None
+
+    async def test_tls_without_hostname_check_enables_tls_insecure(self) -> None:
+        config = Configuration()
+        config.mqtt_host = "localhost"
+        config.mqtt_transport_protocol = TransportProtocol.TLS
+        config.tls_server_cert_check_hostname = False
+        kwargs = await self._connect_and_capture_client_kwargs(config)
+        assert kwargs["tls_insecure"] is True
+        assert kwargs["tls_context"] is not None
+
+    async def test_tls_with_hostname_check_leaves_tls_insecure_unset(self) -> None:
+        config = Configuration()
+        config.mqtt_host = "localhost"
+        config.mqtt_transport_protocol = TransportProtocol.TLS
+        kwargs = await self._connect_and_capture_client_kwargs(config)
+        assert kwargs["tls_insecure"] is None


### PR DESCRIPTION
## Problem

Since the aiomqtt migration (#457), the gateway hangs at startup when configured with a plain `tcp://` broker URI. It logs

```
[INFO]: Connecting to MQTT Broker - mqtt_gateway
[INFO]: MQTT client disconnected - publisher.mqtt_publisher
```

and then does nothing forever: no connection ever reaches the broker, no error is logged, no retry happens, and the process stays alive. 0.12.0 works with the same configuration.

## Root cause

`MqttPublisher.__run_loop` passes `tls_insecure=bool(ssl_context and ...)` to `aiomqtt.Client`. Without TLS that evaluates to `False` rather than `None`, and aiomqtt applies any non-None value via paho's `tls_insecure_set()`, which raises:

```
ValueError: Must configure SSL context before using tls_insecure_set.
```

The ValueError isn't one of the exceptions the reconnect loop handles (`MqttConnectError`/`MqttError`/`CancelledError`), so the connect task dies with only the `finally` block's "MQTT client disconnected" log, the connected event is never set, and `connect()` waits on it forever.

## Fix

Only pass a `tls_insecure` value when TLS is enabled with hostname checking disabled; otherwise leave it `None` so aiomqtt skips `tls_insecure_set()` entirely. Semantics for the TLS cases are unchanged.

Added regression tests covering the three combinations (plain TCP → `None`, TLS without hostname check → `True`, TLS with hostname check → `None`); the plain-TCP and TLS-with-check cases fail against current `develop`. `mypy`, `ruff check`, `ruff format --check` and `pytest` all pass.